### PR TITLE
taking higher priority on specified-network annotation/label on selecting network for pod

### DIFF
--- a/pkg/controller/ipam/pod.go
+++ b/pkg/controller/ipam/pod.go
@@ -375,7 +375,15 @@ func (c *Controller) release(pod *v1.Pod, allocatedIPs []*types.IP) (err error) 
 	return nil
 }
 
+// selectNetwork will pick the hit network by pod, taking the priority as below
+// 1. explicitly specify network in pod annotations/labels
+// 2. parse network type from pod and select a corresponding network bind on node
 func (c *Controller) selectNetwork(pod *v1.Pod) (string, error) {
+	var specifiedNetwork string
+	if specifiedNetwork = utils.PickFirstNonEmptyString(pod.Annotations[constants.AnnotationSpecifiedNetwork], pod.Labels[constants.LabelSpecifiedNetwork]); len(specifiedNetwork) > 0 {
+		return specifiedNetwork, nil
+	}
+
 	var networkType = types.ParseNetworkTypeFromString(utils.PickFirstNonEmptyString(pod.Annotations[constants.AnnotationNetworkType], pod.Labels[constants.LabelNetworkType]))
 	switch networkType {
 	case types.Underlay:


### PR DESCRIPTION
Signed-off-by: Bruce Ma <brucema19901024@gmail.com>

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/hybridnet/blob/main/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

Pull Request Description
---

### Describe what this PR does / why we need it
When pod has a specified-network annotation which direct to a overlay network but has no network-type annotation, then IPAM controller will pick a underlay network which will cause conflicts with the overlay network above.
 
### Does this pull request fix one issue?
NONE

### Describe how you did it
Pick network for pod based on specified-network annotation/label firstly.

### Describe how to verify it
NONE

### Special notes for reviews
NONE