### PR TITLE
bugfix: fix iptables masquerade local pod traffic error

### DIFF
--- a/pkg/daemon/addr/addr.go
+++ b/pkg/daemon/addr/addr.go
@@ -19,7 +19,6 @@ package addr
 import (
 	"fmt"
 	"net"
-	"strings"
 
 	networkingv1 "github.com/alibaba/hybridnet/pkg/apis/networking/v1"
 	"github.com/alibaba/hybridnet/pkg/daemon/containernetwork"
@@ -81,10 +80,7 @@ func (m *Manager) SyncAddresses(getIPInstanceByAddress func(net.IP) (*networking
 
 	for _, link := range linkList {
 		// ignore container network virtual interfaces
-		if strings.HasSuffix(link.Attrs().Name, containernetwork.ContainerHostLinkSuffix) ||
-			strings.HasSuffix(link.Attrs().Name, containernetwork.ContainerInitLinkSuffix) ||
-			strings.HasPrefix(link.Attrs().Name, "veth") {
-
+		if containernetwork.CheckIfContainerNetworkLink(link.Attrs().Name) {
 			continue
 		}
 

--- a/pkg/daemon/containernetwork/constants.go
+++ b/pkg/daemon/containernetwork/constants.go
@@ -20,7 +20,7 @@ const (
 	DockerNetnsDir     = "/var/run/docker/netns"
 	ContainerdNetnsDir = "/var/run/netns/"
 
-	ContainerHostLinkSuffix = "_h"
+	ContainerHostLinkPrefix = "h_"
 	ContainerHostLinkMac    = "ee:ee:ee:ee:ee:ee"
 	ContainerInitLinkSuffix = "_c"
 	VxlanLinkInfix          = ".vxlan"

--- a/pkg/daemon/containernetwork/containernetwork.go
+++ b/pkg/daemon/containernetwork/containernetwork.go
@@ -360,7 +360,16 @@ func ConfigureContainerNic(containerNicName, hostNicName, nodeIfName string, all
 }
 
 func GenerateContainerVethPair(containerID string) (string, string) {
-	return fmt.Sprintf("%s%s", containerID[0:12], ContainerHostLinkSuffix), fmt.Sprintf("%s%s", containerID[0:12], ContainerInitLinkSuffix)
+	return fmt.Sprintf("%s%s", ContainerHostLinkPrefix, containerID[0:12]), fmt.Sprintf("%s%s", containerID[0:12], ContainerInitLinkSuffix)
+}
+
+func CheckIfContainerNetworkLink(linkName string) bool {
+	// TODO: "_h" suffix is deprecated, need to be removed further
+	return strings.HasSuffix(linkName, "_h") ||
+		strings.HasPrefix(linkName, ContainerHostLinkPrefix) ||
+		strings.HasSuffix(linkName, ContainerInitLinkSuffix) ||
+		strings.HasPrefix(linkName, "veth") ||
+		strings.HasPrefix(linkName, "docker")
 }
 
 func ensureRpFilterConfigs(containerHostIf string) error {
@@ -382,7 +391,7 @@ func ensureRpFilterConfigs(containerHostIf string) error {
 	}
 
 	for _, existIf := range existInterfaces {
-		if strings.HasSuffix(existIf.Name, ContainerHostLinkSuffix) || strings.HasSuffix(existIf.Name, ContainerInitLinkSuffix) {
+		if CheckIfContainerNetworkLink(existIf.Name) {
 			continue
 		}
 

--- a/pkg/daemon/containernetwork/utils.go
+++ b/pkg/daemon/containernetwork/utils.go
@@ -216,10 +216,8 @@ func ListLocalAddressExceptLink(exceptLinkName string) ([]netlink.Addr, error) {
 	}
 
 	for _, link := range linkList {
-		if link.Attrs().Name != exceptLinkName &&
-			!strings.HasSuffix(link.Attrs().Name, ContainerHostLinkSuffix) &&
-			!strings.HasPrefix(link.Attrs().Name, "docker") &&
-			!strings.HasPrefix(link.Attrs().Name, "veth") {
+		linkName := link.Attrs().Name
+		if linkName != exceptLinkName && !CheckIfContainerNetworkLink(linkName) {
 
 			linkAddrList, err := ListAllAddress(link)
 			if err != nil {

--- a/pkg/daemon/controller/controller.go
+++ b/pkg/daemon/controller/controller.go
@@ -276,9 +276,7 @@ func (c *Controller) handleLocalNetworkDeviceEvent() error {
 		for {
 			update := <-linkCh
 			if (update.IfInfomsg.Flags&unix.IFF_UP != 0) &&
-				!strings.HasSuffix(update.Link.Attrs().Name, containernetwork.ContainerHostLinkSuffix) &&
-				!strings.HasSuffix(update.Link.Attrs().Name, containernetwork.ContainerInitLinkSuffix) &&
-				!strings.HasPrefix(update.Link.Attrs().Name, "veth") {
+				!containernetwork.CheckIfContainerNetworkLink(update.Link.Attrs().Name) {
 
 				// Create event to flush routes and neigh caches.
 				c.subnetQueue.Add(ActionReconcileSubnet)

--- a/pkg/daemon/controller/ipinstance.go
+++ b/pkg/daemon/controller/ipinstance.go
@@ -301,7 +301,7 @@ func ensureExistPodConfigs(localDirectTableNum int) error {
 		}
 
 		// this container doesn't belong to k8s
-		if !strings.HasSuffix(hostLink.Attrs().Name, containernetwork.ContainerHostLinkSuffix) {
+		if !strings.HasSuffix(hostLink.Attrs().Name, "_h") {
 			continue
 		}
 


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/hybridnet/blob/main/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

Pull Request Description
---

### Describe what this PR does / why we need it
Exist iptables rules will masquerade the traffic from remote pods to local pods, which is not supposed to be done.

### Does this pull request fix one issue?
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
NONE

### Describe how you did it
Ignore the traffic from remote pods to local pods by container host interface name. To do this, interface name "xxx_h" should be changed to "h_xxx", because iptables cannot recognize interfaces by suffix. 

### Describe how to verify it
Use tcpdump in overlay pod, the traffic from remote overlay pods to local pods should not be masqueraded anymore.

### Special notes for reviews
Only new pod's traffic with "h_xxx" interface will be fixed, old pod with "xxx_h" named host interface should be recreate to fix this issue.