### PR TITLE
bugfix: fix iptables-restore unknown arguments found on commandline error on CentOS 8

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -21,7 +21,7 @@ RUN export GOCACHE=/tmp && \
 RUN cd /go/src/github.com/alibaba/hybridnet/dist/secrets && \
     sh generate-tls-certificates.sh
 
-FROM alpine:3.12
+FROM alpine:3.14
 
 # replace apk source url
 RUN sed -i s@/dl-cdn.alpinelinux.org/@/mirrors.aliyun.com/@g /etc/apk/repositories && \

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -21,7 +21,7 @@ RUN export GOCACHE=/tmp && \
 RUN cd /go/src/github.com/alibaba/hybridnet/dist/secrets && \
     sh generate-tls-certificates.sh
 
-FROM arm64v8/alpine:3.12
+FROM arm64v8/alpine:3.14
 
 # replace apk source url
 RUN sed -i s@/dl-cdn.alpinelinux.org/@/mirrors.aliyun.com/@g /etc/apk/repositories && \


### PR DESCRIPTION

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/hybridnet/blob/main/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

Pull Request Description
---

### Describe what this PR does / why we need it
Something wrong will happen if hybridnet is running on a environment of CentOS 8. The iptables-restore in daemon pod will failed and has an error:

`iptables-restore v1.8.4 (nf_tables): unknown arguments found on commandline
Error occurred at line: 3
Try `iptables-restore -h' or 'iptables-restore --help' for more information.`

### Does this pull request fix one issue?
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
NONE

### Describe how you did it
Update alpine 3.12 to 3.14.

### Describe how to verify it
Run hybridnet on CentOS 8.

### Special notes for reviews