### PR TITLE
bugfix: refresh UUID of remote cluster if need and build event pipiline between sub manager and central controller

### DIFF
--- a/pkg/controller/remotecluster/types/event.go
+++ b/pkg/controller/remotecluster/types/event.go
@@ -1,0 +1,29 @@
+/*
+ Copyright 2021 The Hybridnet Authors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package types
+
+type EventType string
+
+type Event struct {
+	Type        EventType
+	ClusterName string
+	Object      interface{}
+}
+
+const (
+	EventRefreshUUID = EventType("RefreshUUID")
+)

--- a/pkg/controller/remotecluster/utils.go
+++ b/pkg/controller/remotecluster/utils.go
@@ -43,7 +43,7 @@ func (c *Controller) syncRemoteClusterManager(remoteCluster *networkingv1.Remote
 	}
 
 	manager, err := rcmanager.NewRemoteClusterManager(remoteCluster, c.kubeClient, c.hybridnetClient, c.remoteSubnetLister,
-		c.localClusterSubnetLister, c.remoteVtepLister)
+		c.localClusterSubnetLister, c.remoteVtepLister, c.remoteClusterEvent)
 	if err != nil {
 		klog.Errorf("fail to create remote cluster manager: %v", err)
 		c.recorder.Event(remoteCluster, corev1.EventTypeWarning, "ErrNewRemoteClusterManager", err.Error())


### PR DESCRIPTION

Signed-off-by: Bruce Ma <brucema19901024@gmail.com>

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/hybridnet/blob/main/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

Pull Request Description
---

### Describe what this PR does / why we need it
1. fix bugfix on UUID refresh of remote clusters
2. build an event pipeline between sub manager and central controller

### Does this pull request fix one issue?
NONE
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
NONE

### Describe how to verify it
NONE

### Special notes for reviews
NONE