### PR TITLE
controller: event from remote cluster manager to trigger status update

### DIFF
--- a/pkg/controller/remotecluster/controller.go
+++ b/pkg/controller/remotecluster/controller.go
@@ -187,7 +187,7 @@ func (c *Controller) Run(stopCh <-chan struct{}) error {
 	// start workers
 	klog.Info("Starting workers")
 	go wait.Until(c.runRemoteClusterWorker, time.Second, stopCh)
-	go wait.Until(c.updateRemoteClusterStatus, HealthCheckPeriod, stopCh)
+	go wait.Until(c.updateAllRemoteClusterStatus, HealthCheckPeriod, stopCh)
 	go wait.Until(c.handleEventFromRemoteClusters, time.Second, stopCh)
 
 	<-stopCh
@@ -239,7 +239,7 @@ func (c *Controller) syncLocalOverlayNetIDOnce() {
 
 // health checking and resync cache. remote cluster is managed by admin, it can be
 // treated as desired states
-func (c *Controller) updateRemoteClusterStatus() {
+func (c *Controller) updateAllRemoteClusterStatus() {
 	remoteClusters, err := c.remoteClusterLister.List(labels.Everything())
 	if err != nil {
 		klog.Errorf("Can't list remote cluster. err=%v", err)
@@ -285,7 +285,27 @@ func (c *Controller) handleEventFromRemoteClusters() {
 			_ = retry.RetryOnConflict(retry.DefaultRetry, func() error {
 				return c.patchUUIDtoRemoteCluster(event.ClusterName, uuid)
 			})
-			klog.Infof("receive and update UUID %s for cluster %s", uuid, event.ClusterName)
+			klog.Infof("receive event and update UUID %s for cluster %s", uuid, event.ClusterName)
+		case rctypes.EventUpdateStatus:
+			if len(event.ClusterName) == 0 {
+				klog.Warningf("invalid cluster for remote cluster event")
+				break
+			}
+
+			remoteCluster, err := c.remoteClusterLister.Get(event.ClusterName)
+			if err != nil {
+				klog.Errorf("update status event fail on getting object: %v", err)
+				break
+			}
+			remoteCluster = remoteCluster.DeepCopy()
+
+			managerObject, ok := c.rcManagerCache.Load(event.ClusterName)
+			if !ok {
+				break
+			}
+
+			go updateSingleRemoteClusterStatus(c, managerObject.(*rcmanager.Manager), remoteCluster)
+			klog.Infof("receive event and update status for cluster %s", event.ClusterName)
 		}
 		time.Sleep(100 * time.Millisecond)
 	}

--- a/pkg/controller/remotecluster/types/event.go
+++ b/pkg/controller/remotecluster/types/event.go
@@ -25,5 +25,6 @@ type Event struct {
 }
 
 const (
-	EventRefreshUUID = EventType("RefreshUUID")
+	EventRefreshUUID  = EventType("RefreshUUID")
+	EventUpdateStatus = EventType("UpdateStatus")
 )

--- a/pkg/rcmanager/rcmanager.go
+++ b/pkg/rcmanager/rcmanager.go
@@ -280,6 +280,11 @@ func (m *Manager) Run() {
 		m.hasSynced = true
 		m.Unlock()
 
+		m.eventHub <- rctypes.Event{
+			Type:        rctypes.EventUpdateStatus,
+			ClusterName: m.Meta.ClusterName,
+		}
+
 		go wait.Until(m.RunNodeWorker, 1*time.Second, managerCh)
 		go wait.Until(m.RunSubnetWorker, 1*time.Second, managerCh)
 		go wait.Until(m.RunIPInstanceWorker, 1*time.Second, managerCh)


### PR DESCRIPTION
Signed-off-by: Bruce Ma <brucema19901024@gmail.com>

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/hybridnet/blob/main/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

Pull Request Description
---

### Describe what this PR does / why we need it
Update cluster status as soon as informer cache sync done.

### Does this pull request fix one issue?
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
NONE

### Describe how you did it
NONE

### Describe how to verify it
NONE

### Special notes for reviews
NONE