### PR TITLE
fix arp proxy exit in large scale cluster

### DIFF
--- a/pkg/daemon/controller/controller.go
+++ b/pkg/daemon/controller/controller.go
@@ -63,6 +63,8 @@ const (
 	NeighUpdateChanSize = 2000
 	LinkUpdateChainSize = 200
 	AddrUpdateChainSize = 200
+
+	NetlinkSubscribeRetryInterval = 10 * time.Second
 )
 
 // Controller is a set of kubernetes controllers
@@ -213,10 +215,13 @@ func NewController(config *daemonconfig.Configuration,
 		UpdateFunc: controller.enqueueUpdateSubnet,
 	})
 
-	ipInstanceInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    controller.enqueueAddOrDeleteIPInstance,
-		UpdateFunc: controller.enqueueUpdateIPInstance,
-		DeleteFunc: controller.enqueueAddOrDeleteIPInstance,
+	ipInstanceInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+		FilterFunc: controller.filterIPInstance,
+		Handler: cache.ResourceEventHandlerFuncs{
+			AddFunc:    controller.enqueueAddOrDeleteIPInstance,
+			UpdateFunc: controller.enqueueUpdateIPInstance,
+			DeleteFunc: controller.enqueueAddOrDeleteIPInstance,
+		},
 	})
 
 	nodeInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -316,33 +321,78 @@ func (c *Controller) GetIPInstanceSynced() cache.InformerSynced {
 //
 // Restart of vxlan interface will also trigger subnet and ip instance reconcile loop.
 func (c *Controller) handleLocalNetworkDeviceEvent() error {
-	linkCh := make(chan netlink.LinkUpdate, LinkUpdateChainSize)
-	if err := netlink.LinkSubscribe(linkCh, nil); err != nil {
-		return fmt.Errorf("subscribe link update event failed %v", err)
+	hostNetNs, err := netns.Get()
+	if err != nil {
+		return fmt.Errorf("get root netns failed: %v", err)
 	}
 
 	go func() {
-		for update := range linkCh {
-			if (update.IfInfomsg.Flags&unix.IFF_UP != 0) &&
-				!containernetwork.CheckIfContainerNetworkLink(update.Link.Attrs().Name) {
+		for {
+			linkCh := make(chan netlink.LinkUpdate, LinkUpdateChainSize)
+			exitCh := make(chan struct{})
 
-				// Create event to flush routes and neigh caches.
-				c.subnetQueue.Add(ActionReconcileSubnet)
-				c.ipInstanceQueue.Add(ActionReconcileIPInstance)
+			errorCallback := func(err error) {
+				klog.Errorf("subscribe netlink link event exit with error: %v", err)
+				close(exitCh)
+			}
+
+			if err := netlink.LinkSubscribeWithOptions(linkCh, nil, netlink.LinkSubscribeOptions{
+				Namespace:     &hostNetNs,
+				ErrorCallback: errorCallback,
+			}); err != nil {
+				klog.Errorf("subscribe link update event failed %v", err)
+				time.Sleep(NetlinkSubscribeRetryInterval)
+				continue
+			}
+
+		linkLoop:
+			for {
+				select {
+				case update := <-linkCh:
+					if (update.IfInfomsg.Flags&unix.IFF_UP != 0) &&
+						!containernetwork.CheckIfContainerNetworkLink(update.Link.Attrs().Name) {
+
+						// Create event to flush routes and neigh caches.
+						c.subnetQueue.Add(ActionReconcileSubnet)
+						c.ipInstanceQueue.Add(ActionReconcileIPInstance)
+					}
+				case <-exitCh:
+					break linkLoop
+				}
 			}
 		}
 	}()
 
-	addrCh := make(chan netlink.AddrUpdate, AddrUpdateChainSize)
-	if err := netlink.AddrSubscribe(addrCh, nil); err != nil {
-		return fmt.Errorf("subscribe address update event failed %v", err)
-	}
-
 	go func() {
-		for update := range addrCh {
-			if containernetwork.CheckIPIsGlobalUnicast(update.LinkAddress.IP) {
-				// Create event to update node configuration.
-				c.nodeQueue.Add(ActionReconcileNode)
+		for {
+			addrCh := make(chan netlink.AddrUpdate, AddrUpdateChainSize)
+			exitCh := make(chan struct{})
+
+			errorCallback := func(err error) {
+				klog.Errorf("subscribe netlink addr event exit with error: %v", err)
+				close(exitCh)
+			}
+
+			if err := netlink.AddrSubscribeWithOptions(addrCh, nil, netlink.AddrSubscribeOptions{
+				Namespace:     &hostNetNs,
+				ErrorCallback: errorCallback,
+			}); err != nil {
+				klog.Errorf("subscribe address update event failed %v", err)
+				time.Sleep(NetlinkSubscribeRetryInterval)
+				continue
+			}
+
+		addrLoop:
+			for {
+				select {
+				case update := <-addrCh:
+					if containernetwork.CheckIPIsGlobalUnicast(update.LinkAddress.IP) {
+						// Create event to update node configuration.
+						c.nodeQueue.Add(ActionReconcileNode)
+					}
+				case <-exitCh:
+					break addrLoop
+				}
 			}
 		}
 	}()
@@ -425,49 +475,65 @@ func (c *Controller) handleVxlanInterfaceNeighEvent() error {
 		}
 	}
 
-	ch := make(chan netlink.NeighUpdate, NeighUpdateChanSize)
-
-	// clear stale neigh entries for vxlan interface at the first time
-	linkList, err := netlink.LinkList()
-	if err != nil {
-		return fmt.Errorf("list link failed: %v", err)
-	}
-
-	for _, link := range linkList {
-		if strings.Contains(link.Attrs().Name, containernetwork.VxlanLinkInfix) {
-			if err := neigh.ClearStaleNeighEntries(link.Attrs().Index); err != nil {
-				return fmt.Errorf("clear stale neigh entries for link %v failed: %v",
-					link.Attrs().Name, err)
-			}
-		}
-	}
-
 	hostNetNs, err := netns.Get()
 	if err != nil {
 		return fmt.Errorf("get root netns failed: %v", err)
 	}
 
-	if err := netlink.NeighSubscribeAt(hostNetNs, ch, nil); err != nil {
-		return fmt.Errorf("subscribe neigh update event failed: %v", err)
-	}
+	timer := time.NewTicker(c.config.VxlanExpiredNeighCachesClearInterval)
+	errorMessageWrapper := initErrorMessageWrapper("handle vxlan interface neigh event failed: ")
 
 	go func() {
-		errorMessageWrapper := initErrorMessageWrapper("handle vxlan interface neigh event failed: ")
+		for {
+			// Clear stale and failed neigh entries for vxlan interface at the first time.
+			// Once neigh subscribe failed (include the goroutine exit), it's most probably because of
+			// "No buffer space available" problem, we need to clean expired neigh caches.
+			if err := clearVxlanExpiredNeighCaches(); err != nil {
+				klog.Errorf("clear vxlan expired neigh caches failed: %v", err)
+			}
 
-		for update := range ch {
-			if isNeighResolving(update.State) {
-				if update.Type == syscall.RTM_DELNEIGH {
-					continue
-				}
+			neighCh := make(chan netlink.NeighUpdate, NeighUpdateChanSize)
+			exitCh := make(chan struct{})
 
-				link, err := netlink.LinkByIndex(update.LinkIndex)
-				if err != nil {
-					klog.Errorf(errorMessageWrapper("get link by index %v failed: %v", update.LinkIndex, err))
-					continue
-				}
+			errorCallback := func(err error) {
+				klog.Errorf("subscribe netlink neigh event exit with error: %v", err)
+				close(exitCh)
+			}
 
-				if strings.Contains(link.Attrs().Name, containernetwork.VxlanLinkInfix) {
-					go ipSearchExecWrapper(update.IP, link)
+			if err := netlink.NeighSubscribeWithOptions(neighCh, nil, netlink.NeighSubscribeOptions{
+				Namespace:     &hostNetNs,
+				ErrorCallback: errorCallback,
+			}); err != nil {
+				klog.Errorf("subscribe neigh update event failed: %v", err)
+				time.Sleep(NetlinkSubscribeRetryInterval)
+				continue
+			}
+
+		neighLoop:
+			for {
+				select {
+				case update := <-neighCh:
+					if isNeighResolving(update.State) {
+						if update.Type == syscall.RTM_DELNEIGH {
+							continue
+						}
+
+						link, err := netlink.LinkByIndex(update.LinkIndex)
+						if err != nil {
+							klog.Errorf(errorMessageWrapper("get link by index %v failed: %v", update.LinkIndex, err))
+							continue
+						}
+
+						if strings.Contains(link.Attrs().Name, containernetwork.VxlanLinkInfix) {
+							go ipSearchExecWrapper(update.IP, link)
+						}
+					}
+				case <-timer.C:
+					if err := clearVxlanExpiredNeighCaches(); err != nil {
+						klog.Errorf("clear vxlan expired neigh caches failed: %v", err)
+					}
+				case <-exitCh:
+					break neighLoop
 				}
 			}
 		}
@@ -654,7 +720,8 @@ func (c *Controller) runHealthyServer() {
 }
 
 func isNeighResolving(state int) bool {
-	return (state & (netlink.NUD_INCOMPLETE | netlink.NUD_STALE | netlink.NUD_DELAY | netlink.NUD_PROBE)) != 0
+	// We need a neigh cache to be STALE if it's not used for a while.
+	return (state & netlink.NUD_INCOMPLETE) != 0
 }
 
 func indexByInstanceIP(obj interface{}) ([]string, error) {
@@ -679,4 +746,22 @@ var indexByEndpointIP cache.IndexFunc = func(obj interface{}) ([]string, error) 
 		}
 	}
 	return []string{}, nil
+}
+
+func clearVxlanExpiredNeighCaches() error {
+	linkList, err := netlink.LinkList()
+	if err != nil {
+		return fmt.Errorf("list link failed: %v", err)
+	}
+
+	for _, link := range linkList {
+		if strings.Contains(link.Attrs().Name, containernetwork.VxlanLinkInfix) {
+			if err := neigh.ClearStaleAddFailedNeighEntries(link.Attrs().Index); err != nil {
+				return fmt.Errorf("clear stale neigh entries for link %v failed: %v",
+					link.Attrs().Name, err)
+			}
+		}
+	}
+
+	return nil
 }

--- a/pkg/daemon/controller/ipinstance.go
+++ b/pkg/daemon/controller/ipinstance.go
@@ -37,6 +37,16 @@ import (
 	"k8s.io/klog"
 )
 
+func (c *Controller) filterIPInstance(obj interface{}) bool {
+	p, ok := obj.(*networkingv1.IPInstance)
+	if !ok {
+		return false
+	}
+
+	// only ip on this node
+	return p.Labels[constants.LabelNode] == c.config.NodeName
+}
+
 func (c *Controller) enqueueAddOrDeleteIPInstance(obj interface{}) {
 	c.ipInstanceQueue.Add(ActionReconcileIPInstance)
 }

--- a/pkg/daemon/neigh/utils.go
+++ b/pkg/daemon/neigh/utils.go
@@ -46,7 +46,7 @@ func ClearStaleNeighEntryByIP(linkIndex int, ip net.IP) error {
 	return nil
 }
 
-func ClearStaleNeighEntries(linkIndex int) error {
+func ClearStaleAddFailedNeighEntries(linkIndex int) error {
 	for _, family := range []int{netlink.FAMILY_V4, netlink.FAMILY_V6} {
 		neighList, err := netlink.NeighList(linkIndex, family)
 		if err != nil {
@@ -54,7 +54,7 @@ func ClearStaleNeighEntries(linkIndex int) error {
 		}
 
 		for _, neigh := range neighList {
-			if neigh.State == netlink.NUD_STALE {
+			if neigh.State == netlink.NUD_STALE || neigh.State == netlink.NUD_FAILED {
 				if err := netlink.NeighDel(&neigh); err != nil {
 					return fmt.Errorf("del neigh cache %v error: %v", neigh.String(), err)
 				}


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/hybridnet/blob/main/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

Pull Request Description
---

### Describe what this PR does / why we need it
In a large scale cluster, the number of vxlan neigh cache entries on the every node might grow to a huge size, which will bring a "No buffer space available" failure for netlink.NeighSubscribe function. Once NeighSubscribe function is exit, userspace arp proxy will never start again. (The NeighSubscribe function will also close the event channel passed to it.)

### Does this pull request fix one issue?
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
NONE.

### Describe how you did it
In this PR, I fix the NeighSubscribe exist problem and change the behaviors of arp proxy to control the size of neigh cache size:
1. Multicast arp/ndp request will only be sent if a neigh cache is `INCOMPLETE`, in other words, when neigh cache is just created. So we just need to handle the `INCOMPLETE` netlink neigh event, and proxy arp for it.
2. Unicast arp/ndp probe request will be sent if a neigh cache's state is changed from `STALE` to `PROBE`. This will not be handled in arp proxy, so every neigh cache can be `STALE`. Every pod will generate an arp unicast probe for every 5 second. Because `unicast_solicit` has a higher priority than `app_solicit`, we cannot handle the netlink events of `NUD_DELAY` or `NUD_PROBE` before the unicast arp probe packet is send out.
3. ~~Gratuitous arp/ndp packets will be sent on overlay forward interface once, while an overlay/underlay pod is being created.~~
4. Daemon will clean STALE and FAILED neigh caches periodically on vxlan interface, default once an hour.

### Describe how to verify it

### Special notes for reviews