### PR TITLE
feature: introduce felix for networkpolicy

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -1,6 +1,7 @@
 FROM golang:1.15.7 as builder
 
 ENV ARCH=amd64
+ENV OS=linux
 
 WORKDIR /go/src/github.com/alibaba/hybridnet
 
@@ -16,7 +17,7 @@ RUN export GOCACHE=/tmp && \
     export GO111MODULE=on && \
     export GOARCH=${ARCH} && \
     export CGO_ENABLED=0 && \
-    export GOOS=linux && \
+    export GOOS=${OS} && \
     export COMMIT_ID=`git rev-parse --short HEAD 2>/dev/null` && \
     go build -o dist/images/hybridnet -ldflags "-w -s" -v ./cmd/cni && \
     go build -ldflags "-w -s -X \"main.gitCommit=`echo $COMMIT_ID`\" " -o dist/images/hybridnet-daemon -v ./cmd/daemon && \
@@ -26,6 +27,36 @@ RUN export GOCACHE=/tmp && \
 
 RUN cd /go/src/github.com/alibaba/hybridnet/dist/secrets && \
     sh generate-tls-certificates.sh
+
+FROM calico/go-build:v0.57 as felix-builder
+ARG GOPROXY
+ENV GOPROXY $GOPROXY
+ENV GIT_BRANCH=v3.20.2
+ENV GIT_COMMIT=ab06c3940caa8ac201f85c1313b2d72d724409d2
+
+ENV ARCH=amd64
+ENV OS=linux
+
+RUN mkdir -p /go/src/github.com/projectcalico/ && cd /go/src/github.com/projectcalico/ && \
+    git clone -b ${GIT_BRANCH} --depth 1 https://github.com/projectcalico/felix.git && \
+    cd felix && [ "`git rev-parse HEAD`" = "${GIT_COMMIT}" ]
+COPY policy/felix /hybridnet_patch
+RUN cd /go/src/github.com/projectcalico/felix && git apply /hybridnet_patch/*.patch
+RUN cd /go/src/github.com/projectcalico/felix && \
+    export GOCACHE=/tmp && \
+    export GO111MODULE=on && \
+    export GOARCH=${ARCH} && \
+    export CGO_ENABLED=0 && \
+    export GOOS=${OS} && \
+    go build -v -o bin/calico-felix -v -ldflags \
+    "-X github.com/projectcalico/felix/buildinfo.GitVersion=${GIT_BRANCH} \
+    -X github.com/projectcalico/felix/buildinfo.BuildDate=$(date -u +'%FT%T%z') \
+    -X github.com/projectcalico/felix/buildinfo.GitRevision=${GIT_COMMIT} \
+    -B 0x${GIT_COMMIT}" "github.com/projectcalico/felix/cmd/calico-felix" && \
+    ( ldd bin/calico-felix 2>&1 | grep -q -e "Not a valid dynamic program" \
+    -e "not a dynamic executable" || \
+    ( echo "Error: bin/calico-felix was not statically linked"; false ) ) \
+    && chmod +x /go/src/github.com/projectcalico/felix/bin/calico-felix
 
 FROM alpine:3.14
 
@@ -63,6 +94,9 @@ COPY --from=builder /go/src/github.com/alibaba/hybridnet/dist/images/hybridnet-d
 COPY --from=builder /go/src/github.com/alibaba/hybridnet/dist/images/hybridnet-manager /hybridnet/hybridnet-manager
 COPY --from=builder /go/src/github.com/alibaba/hybridnet/dist/images/hybridnet-webhook /hybridnet/hybridnet-webhook
 COPY --from=builder /go/src/github.com/alibaba/hybridnet/COMMIT_ID /hybridnet/COMMIT_ID
+
+COPY --from=felix-builder /go/src/github.com/projectcalico/felix/bin/calico-felix /hybridnet/calico-felix
+COPY policy/policyinit.sh /hybridnet/
 
 RUN mkdir -p /tmp/k8s-webhook-server/serving-certs
 

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -1,6 +1,7 @@
 FROM golang:1.15.7 as builder
 
 ENV ARCH=arm64
+ENV OS=linux
 
 WORKDIR /go/src/github.com/alibaba/hybridnet
 
@@ -16,7 +17,7 @@ RUN export GOCACHE=/tmp && \
     export GO111MODULE=on && \
     export GOARCH=${ARCH} && \
     export CGO_ENABLED=0 && \
-    export GOOS=linux && \
+    export GOOS=${OS} && \
     export COMMIT_ID=`git rev-parse --short HEAD 2>/dev/null` && \
     go build -o dist/images/hybridnet -ldflags "-w -s" -v ./cmd/cni && \
     go build -ldflags "-w -s -X \"main.gitCommit=`echo $COMMIT_ID`\" " -o dist/images/hybridnet-daemon -v ./cmd/daemon && \
@@ -26,6 +27,36 @@ RUN export GOCACHE=/tmp && \
 
 RUN cd /go/src/github.com/alibaba/hybridnet/dist/secrets && \
     sh generate-tls-certificates.sh
+
+FROM calico/go-build:v0.57 as felix-builder
+ARG GOPROXY
+ENV GOPROXY $GOPROXY
+ENV GIT_BRANCH=v3.20.2
+ENV GIT_COMMIT=ab06c3940caa8ac201f85c1313b2d72d724409d2
+
+ENV ARCH=arm64
+ENV OS=linux
+
+RUN mkdir -p /go/src/github.com/projectcalico/ && cd /go/src/github.com/projectcalico/ && \
+    git clone -b ${GIT_BRANCH} --depth 1 https://github.com/projectcalico/felix.git && \
+    cd felix && [ "`git rev-parse HEAD`" = "${GIT_COMMIT}" ]
+COPY policy/felix /hybridnet_patch
+RUN cd /go/src/github.com/projectcalico/felix && git apply /hybridnet_patch/*.patch
+RUN cd /go/src/github.com/projectcalico/felix && \
+    export GOCACHE=/tmp && \
+    export GO111MODULE=on && \
+    export GOARCH=${ARCH} && \
+    export CGO_ENABLED=0 && \
+    export GOOS=${OS} && \
+    go build -v -o bin/calico-felix -v -ldflags \
+    "-X github.com/projectcalico/felix/buildinfo.GitVersion=${GIT_BRANCH} \
+    -X github.com/projectcalico/felix/buildinfo.BuildDate=$(date -u +'%FT%T%z') \
+    -X github.com/projectcalico/felix/buildinfo.GitRevision=${GIT_COMMIT} \
+    -B 0x${GIT_COMMIT}" "github.com/projectcalico/felix/cmd/calico-felix" && \
+    ( ldd bin/calico-felix 2>&1 | grep -q -e "Not a valid dynamic program" \
+    -e "not a dynamic executable" || \
+    ( echo "Error: bin/calico-felix was not statically linked"; false ) ) \
+    && chmod +x /go/src/github.com/projectcalico/felix/bin/calico-felix
 
 FROM arm64v8/alpine:3.14
 
@@ -63,6 +94,9 @@ COPY --from=builder /go/src/github.com/alibaba/hybridnet/dist/images/hybridnet-d
 COPY --from=builder /go/src/github.com/alibaba/hybridnet/dist/images/hybridnet-manager /hybridnet/hybridnet-manager
 COPY --from=builder /go/src/github.com/alibaba/hybridnet/dist/images/hybridnet-webhook /hybridnet/hybridnet-webhook
 COPY --from=builder /go/src/github.com/alibaba/hybridnet/COMMIT_ID /hybridnet/COMMIT_ID
+
+COPY --from=felix-builder /go/src/github.com/projectcalico/felix/bin/calico-felix /hybridnet/calico-felix
+COPY policy/policyinit.sh /hybridnet/
 
 RUN mkdir -p /tmp/k8s-webhook-server/serving-certs
 

--- a/pkg/daemon/containernetwork/constants.go
+++ b/pkg/daemon/containernetwork/constants.go
@@ -20,7 +20,7 @@ const (
 	DockerNetnsDir     = "/var/run/docker/netns"
 	ContainerdNetnsDir = "/var/run/netns/"
 
-	ContainerHostLinkPrefix = "h_"
+	ContainerHostLinkPrefix = "hybr"
 	ContainerHostLinkMac    = "ee:ee:ee:ee:ee:ee"
 	ContainerInitLinkSuffix = "_c"
 	VxlanLinkInfix          = ".vxlan"

--- a/pkg/daemon/iptables/iptables.go
+++ b/pkg/daemon/iptables/iptables.go
@@ -256,6 +256,7 @@ func (mgr *Manager) SyncRules() error {
 		//
 		// Append rules.
 		writeLine(natRules, generateSkipMasqueradeRuleSpec()...)
+		writeLine(natRules, generateOldSkipMasqueradeRuleSpec()...)
 		writeLine(natRules, generateMasqueradeRuleSpec(mgr.overlayIfName, mgr.protocol)...)
 		writeLine(filterRules, generateVxlanFilterRuleSpec(mgr.overlayIfName, mgr.protocol)...)
 		writeLine(mangleRules, generateVxlanPodToNodeReplyMarkRuleSpec(mgr.protocol)...)
@@ -369,6 +370,12 @@ func generateMasqueradeRuleSpec(vxlanIf string, protocol Protocol) []string {
 func generateSkipMasqueradeRuleSpec() []string {
 	return []string{"-A", ChainHybridnetPostRouting, "-m", "comment", "--comment", `"skip masquerade if traffic is to local pod"`,
 		"-o", containernetwork.ContainerHostLinkPrefix + "+", "-j", "RETURN"}
+}
+
+// TODO: update logic, need to be removed further
+func generateOldSkipMasqueradeRuleSpec() []string {
+	return []string{"-A", ChainHybridnetPostRouting, "-m", "comment", "--comment", `"skip masquerade if traffic is to exist old local pod"`,
+		"-o", "h_+", "-j", "RETURN"}
 }
 
 func generateVxlanFilterRuleSpec(vxlanIf string, protocol Protocol) []string {

--- a/pkg/daemon/server/container.go
+++ b/pkg/daemon/server/container.go
@@ -50,7 +50,7 @@ func (cdh cniDaemonHandler) configureNic(podName, podNamespace, netns, container
 		return "", fmt.Errorf("failed to parse mac %s %v", macAddr, err)
 	}
 
-	containerNicName, hostNicName, podNS, err := initContainerNic(podName, netns, containerID, mtu)
+	containerNicName, hostNicName, podNS, err := initContainerNic(podName, podNamespace, netns, mtu)
 	if err != nil {
 		return "", fmt.Errorf("init container nic for pod %v failed: %v", podName, err)
 	}
@@ -110,7 +110,7 @@ func (cdh cniDaemonHandler) deleteNic(netns string) error {
 	})
 }
 
-func initContainerNic(podName, netns, containerID string, mtu int) (string, string, ns.NetNS, error) {
+func initContainerNic(podName, podNamespace, netns string, mtu int) (string, string, ns.NetNS, error) {
 	podNS, err := ns.GetNS(netns)
 	if err != nil {
 		return "", "", nil, fmt.Errorf("failed to open netns %q: %v", netns, err)
@@ -121,7 +121,7 @@ func initContainerNic(podName, netns, containerID string, mtu int) (string, stri
 		return "", "", nil, fmt.Errorf("failed to open current namespace: %v", err)
 	}
 
-	hostNicName, containerNicName := containernetwork.GenerateContainerVethPair(containerID)
+	hostNicName, containerNicName := containernetwork.GenerateContainerVethPair(podNamespace, podName)
 
 	if err := ns.WithNetNSPath(podNS.Path(), func(_ ns.NetNS) error {
 		veth := netlink.Veth{

--- a/policy/felix/0001-hybridnet.patch
+++ b/policy/felix/0001-hybridnet.patch
@@ -1,0 +1,263 @@
+From 1dfe30bb4f7223332b92564cc2bbbebae0cb43d0 Mon Sep 17 00:00:00 2001
+From: hhyasdf <552483776@qq.com>
+Date: Mon, 27 Dec 2021 20:22:29 +0800
+Subject: [PATCH] hybridnet
+
+---
+ calc/calc_graph.go               |  4 +--
+ daemon/daemon.go                 | 56 ++++++++++++++++----------------
+ dataplane/linux/endpoint_mgr.go  | 34 +++++++++----------
+ dataplane/linux/masq_mgr.go      |  8 ++++-
+ iptables/feature_detect.go       | 11 +++++++
+ iptables/features_detect_test.go | 18 ++++++++++
+ 6 files changed, 83 insertions(+), 48 deletions(-)
+
+diff --git a/calc/calc_graph.go b/calc/calc_graph.go
+index abe9ca29..a39193e1 100644
+--- a/calc/calc_graph.go
++++ b/calc/calc_graph.go
+@@ -380,8 +380,8 @@ func NewCalculationGraph(callbacks PipelineCallbacks, conf *config.Config) *Calc
+ 	//         |
+ 	//      <dataplane>
+ 	//
+-	configBatcher := NewConfigBatcher(hostname, callbacks)
+-	configBatcher.RegisterWith(allUpdDispatcher)
++	//configBatcher := NewConfigBatcher(hostname, callbacks)
++	//configBatcher.RegisterWith(allUpdDispatcher)
+ 
+ 	// The profile decoder identifies objects with special dataplane significance which have
+ 	// been encoded as profiles by libcalico-go. At present this includes Kubernetes Service
+diff --git a/daemon/daemon.go b/daemon/daemon.go
+index 21cf78ef..98488d56 100644
+--- a/daemon/daemon.go
++++ b/daemon/daemon.go
+@@ -119,7 +119,7 @@ func Run(configFile string, gitVersion string, buildDate string, gitRevision str
+ 	// Initialise early so we can trace out config parsing.
+ 	logutils.ConfigureEarlyLogging()
+ 
+-	ctx := context.Background()
++	//ctx := context.Background()
+ 
+ 	if os.Getenv("GOGC") == "" {
+ 		// Tune the GC to trade off a little extra CPU usage for significantly lower
+@@ -233,33 +233,33 @@ configRetry:
+ 		log.Info("Created datastore client")
+ 		numClientsCreated++
+ 		backendClient = v3Client.(interface{ Backend() bapi.Client }).Backend()
+-		for {
+-			globalConfig, hostConfig, err := loadConfigFromDatastore(
+-				ctx, backendClient, datastoreConfig, configParams.FelixHostname)
+-			if err == ErrNotReady {
+-				log.Warn("Waiting for datastore to be initialized (or migrated)")
+-				time.Sleep(1 * time.Second)
+-				healthAggregator.Report(healthName, &health.HealthReport{Live: true, Ready: true})
+-				continue
+-			} else if err != nil {
+-				log.WithError(err).Error("Failed to get config from datastore")
+-				time.Sleep(1 * time.Second)
+-				continue configRetry
+-			}
+-			_, err = configParams.UpdateFrom(globalConfig, config.DatastoreGlobal)
+-			if err != nil {
+-				log.WithError(err).Error("Failed update global config from datastore")
+-				time.Sleep(1 * time.Second)
+-				continue configRetry
+-			}
+-			_, err = configParams.UpdateFrom(hostConfig, config.DatastorePerHost)
+-			if err != nil {
+-				log.WithError(err).Error("Failed update host config from datastore")
+-				time.Sleep(1 * time.Second)
+-				continue configRetry
+-			}
+-			break
+-		}
++		//for {
++		//	globalConfig, hostConfig, err := loadConfigFromDatastore(
++		//		ctx, backendClient, datastoreConfig, configParams.FelixHostname)
++		//	if err == ErrNotReady {
++		//		log.Warn("Waiting for datastore to be initialized (or migrated)")
++		//		time.Sleep(1 * time.Second)
++		//		healthAggregator.Report(healthName, &health.HealthReport{Live: true, Ready: true})
++		//		continue
++		//	} else if err != nil {
++		//		log.WithError(err).Error("Failed to get config from datastore")
++		//		time.Sleep(1 * time.Second)
++		//		continue configRetry
++		//	}
++		//	_, err = configParams.UpdateFrom(globalConfig, config.DatastoreGlobal)
++		//	if err != nil {
++		//		log.WithError(err).Error("Failed update global config from datastore")
++		//		time.Sleep(1 * time.Second)
++		//		continue configRetry
++		//	}
++		//	_, err = configParams.UpdateFrom(hostConfig, config.DatastorePerHost)
++		//	if err != nil {
++		//		log.WithError(err).Error("Failed update host config from datastore")
++		//		time.Sleep(1 * time.Second)
++		//		continue configRetry
++		//	}
++		//	break
++		//}
+ 		err = configParams.Validate()
+ 		if err != nil {
+ 			log.WithError(err).Error("Failed to parse/validate configuration from datastore.")
+diff --git a/dataplane/linux/endpoint_mgr.go b/dataplane/linux/endpoint_mgr.go
+index e8c74dad..3cace0e7 100644
+--- a/dataplane/linux/endpoint_mgr.go
++++ b/dataplane/linux/endpoint_mgr.go
+@@ -542,7 +542,7 @@ func (m *endpointManager) resolveWorkloadEndpoints() {
+ 			// Remove any routes from the routing table.  The RouteTable will remove any
+ 			// conntrack entries as a side-effect.
+ 			logCxt.Info("Workload removed, deleting old state.")
+-			m.routeTable.SetRoutes(oldWorkload.Name, nil)
++			//m.routeTable.SetRoutes(oldWorkload.Name, nil)
+ 			m.wlIfaceNamesToReconfigure.Discard(oldWorkload.Name)
+ 			delete(m.activeWlIfaceNameToID, oldWorkload.Name)
+ 		}
+@@ -587,7 +587,7 @@ func (m *endpointManager) resolveWorkloadEndpoints() {
+ 					if !m.bpfEnabled {
+ 						m.filterTable.RemoveChains(m.activeWlIDToChains[id])
+ 					}
+-					m.routeTable.SetRoutes(oldWorkload.Name, nil)
++					//m.routeTable.SetRoutes(oldWorkload.Name, nil)
+ 					m.wlIfaceNamesToReconfigure.Discard(oldWorkload.Name)
+ 					delete(m.activeWlIfaceNameToID, oldWorkload.Name)
+ 				}
+@@ -656,7 +656,7 @@ func (m *endpointManager) resolveWorkloadEndpoints() {
+ 				} else {
+ 					logCxt.Debug("Endpoint down, removing routes")
+ 				}
+-				m.routeTable.SetRoutes(workload.Name, routeTargets)
++				//m.routeTable.SetRoutes(workload.Name, routeTargets)
+ 				m.wlIfaceNamesToReconfigure.Add(workload.Name)
+ 				m.activeWlEndpoints[id] = workload
+ 				m.activeWlIfaceNameToID[workload.Name] = id
+@@ -704,20 +704,20 @@ func (m *endpointManager) resolveWorkloadEndpoints() {
+ 		m.needToCheckEndpointMarkChains = true
+ 	}
+ 
+-	m.wlIfaceNamesToReconfigure.Iter(func(item interface{}) error {
+-		ifaceName := item.(string)
+-		err := m.configureInterface(ifaceName)
+-		if err != nil {
+-			if exists, err := m.interfaceExistsInProcSys(ifaceName); err == nil && !exists {
+-				// Suppress log spam if interface has been removed.
+-				log.WithError(err).Debug("Failed to configure interface and it seems to be gone")
+-			} else {
+-				log.WithError(err).Warn("Failed to configure interface, will retry")
+-			}
+-			return nil
+-		}
+-		return set.RemoveItem
+-	})
++	//m.wlIfaceNamesToReconfigure.Iter(func(item interface{}) error {
++	//	ifaceName := item.(string)
++	//	err := m.configureInterface(ifaceName)
++	//	if err != nil {
++	//		if exists, err := m.interfaceExistsInProcSys(ifaceName); err == nil && !exists {
++	//			// Suppress log spam if interface has been removed.
++	//			log.WithError(err).Debug("Failed to configure interface and it seems to be gone")
++	//		} else {
++	//			log.WithError(err).Warn("Failed to configure interface, will retry")
++	//		}
++	//		return nil
++	//	}
++	//	return set.RemoveItem
++	//})
+ }
+ 
+ func wlIdsAscending(id1, id2 *proto.WorkloadEndpointID) bool {
+diff --git a/dataplane/linux/masq_mgr.go b/dataplane/linux/masq_mgr.go
+index 402a4507..09a451a4 100644
+--- a/dataplane/linux/masq_mgr.go
++++ b/dataplane/linux/masq_mgr.go
+@@ -15,6 +15,7 @@
+ package intdataplane
+ 
+ import (
++	"os"
+ 	"strings"
+ 
+ 	log "github.com/sirupsen/logrus"
+@@ -69,6 +70,11 @@ func newMasqManager(
+ 		Type:    ipsets.IPSetTypeHashNet,
+ 	}, []string{})
+ 
++	if os.Getenv("CALICO_IPV4POOL_CIDR") != "" {
++		ipsetsDataplane.AddMembers(rules.IPSetIDNATOutgoingMasqPools, []string{os.Getenv("CALICO_IPV4POOL_CIDR")})
++		ipsetsDataplane.AddMembers(rules.IPSetIDNATOutgoingAllPools, []string{os.Getenv("CALICO_IPV4POOL_CIDR")})
++	}
++
+ 	return &masqManager{
+ 		ipVersion:       ipVersion,
+ 		ipsetsDataplane: ipsetsDataplane,
+@@ -142,7 +148,7 @@ func (m *masqManager) CompleteDeferredWork() error {
+ 	// Refresh the chain in case we've gone from having no masq pools to
+ 	// having some or vice-versa.
+ 	m.logCxt.Info("IPAM pools updated, refreshing iptables rule")
+-	chain := m.ruleRenderer.NATOutgoingChain(m.masqPools.Len() > 0, m.ipVersion)
++	chain := m.ruleRenderer.NATOutgoingChain(true, m.ipVersion)
+ 	m.natTable.UpdateChain(chain)
+ 	m.dirty = false
+ 
+diff --git a/iptables/feature_detect.go b/iptables/feature_detect.go
+index 0a940e69..603baad7 100644
+--- a/iptables/feature_detect.go
++++ b/iptables/feature_detect.go
+@@ -43,6 +43,11 @@ var (
+ 	// Linux kernel versions:
+ 	// v3Dot10Dot0 is the oldest version we support at time of writing.
+ 	v3Dot10Dot0 = versionparse.MustParseVersion("3.10.0")
++
++	// RHEL spec kernel versions:
++	v3Dot10Dot1   = versionparse.MustParseVersion("3.10.1")
++	v3Dot10Dot693 = versionparse.MustParseVersion("3.10.0-693")
++
+ 	// v3Dot14Dot0 added the random-fully feature on the iptables interface.
+ 	v3Dot14Dot0 = versionparse.MustParseVersion("3.14.0")
+ 	// v5Dot7Dot0 contains a fix for checksum offloading.
+@@ -145,6 +150,12 @@ func (d *FeatureDetector) refreshFeaturesLockHeld() {
+ 	// Avoid logging all the override values every time through this function.
+ 	d.loggedOverrides = true
+ 
++	// for rhel/centos >= 7.4 which backport fully-random
++	if kerV.Compare(v3Dot10Dot1) < 0 && kerV.Compare(v3Dot10Dot693) >= 0 {
++		features.SNATFullyRandom = true
++		features.MASQFullyRandom = true
++	}
++
+ 	if d.featureCache == nil || *d.featureCache != features {
+ 		log.WithFields(log.Fields{
+ 			"features":        features,
+diff --git a/iptables/features_detect_test.go b/iptables/features_detect_test.go
+index bd74e130..f4b66d71 100644
+--- a/iptables/features_detect_test.go
++++ b/iptables/features_detect_test.go
+@@ -125,6 +125,24 @@ func TestFeatureDetection(t *testing.T) {
+ 				ChecksumOffloadBroken: false,
+ 			},
+ 		},
++		{
++			"iptables v1.6.2",
++			"Linux version 3.10.0-693.21.3.el7.x86_64",
++			Features{
++				RestoreSupportsLock: true,
++				SNATFullyRandom:     true,
++				MASQFullyRandom:     true,
++			},
++		},
++		{
++			"iptables v1.6.2",
++			"Linux version 3.10.1-693.21.3.el7.x86_64",
++			Features{
++				RestoreSupportsLock: true,
++				SNATFullyRandom:     false,
++				MASQFullyRandom:     false,
++			},
++		},
+ 	} {
+ 		tst := tst
+ 		t.Run("iptables version "+tst.iptablesVersion+" kernel "+tst.kernelVersion, func(t *testing.T) {
+-- 
+2.30.1 (Apple Git-130)
+

--- a/policy/policyinit.sh
+++ b/policy/policyinit.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+export DATASTORE_TYPE=kubernetes
+if [ "$DATASTORE_TYPE" = "kubernetes" ]; then
+    if [ -z "$KUBERNETES_SERVICE_HOST" ]; then
+        echo "can not found k8s apiserver service env, exiting"
+        exit 1
+    fi
+    return_code="$(curl -k -o /dev/null -I -L -s -w "%{http_code}" https://"${KUBERNETES_SERVICE_HOST}":"${KUBERNETES_SERVICE_PORT:-443}")"
+    if [ "$return_code" -ne 403 ]&&[ "$return_code" -ne 200 ]&&[ "$return_code" -ne 201 ];then
+        echo "can not access kubernetes service, exiting"
+        exit 1
+    fi
+fi
+
+# default for veth
+export FELIX_LOGSEVERITYSYS=none
+export FELIX_LOGSEVERITYSCREEN=info
+export CALICO_NETWORKING_BACKEND=none
+export CLUSTER_TYPE=k8s,aliyun
+export CALICO_DISABLE_FILE_LOGGING=true
+# shellcheck disable=SC2154
+export FELIX_IPTABLESREFRESHINTERVAL="${IPTABLESREFRESHINTERVAL:-60}"
+export FELIX_IPV6SUPPORT=true
+export WAIT_FOR_DATASTORE=true
+export NO_DEFAULT_POOLS=true
+export FELIX_DEFAULTENDPOINTTOHOSTACTION=ACCEPT
+export FELIX_HEALTHENABLED=true
+export FELIX_LOGFILEPATH=/dev/null
+export FELIX_BPFENABLED=false
+export FELIX_XDPENABLED=false
+export FELIX_BPFCONNECTTIMELOADBALANCINGENABLED=false
+export FELIX_BPFKUBEPROXYIPTABLESCLEANUPENABLED=false
+
+export FELIX_ALLOWVXLANPACKETSFROMWORKLOADS=true
+export FELIX_ALLOWIPIPPACKETSFROMWORKLOADS=true
+export FELIX_INTERFACEPREFIX="hybr"
+
+export FELIX_IPTABLESMANGLEALLOWACTION=RETURN
+
+exec 2>&1
+
+if [ -n "$NODENAME" ]; then
+    export FELIX_FELIXHOSTNAME="$NODENAME"
+fi
+
+if [ -n "$DATASTORE_TYPE" ]; then
+    export FELIX_DATASTORETYPE="$DATASTORE_TYPE"
+fi
+
+if [ "$(cat /sys/module/ipv6/parameters/disable)" -ne "0" ]; then
+    export FELIX_IPV6SUPPORT=false
+fi
+
+exec /hybridnet/calico-felix

--- a/policy/uninstall_policy.sh
+++ b/policy/uninstall_policy.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+cleanup_felix() {
+    # Set FORWARD action to ACCEPT so outgoing packets can go through POSTROUTING chains.
+    echo "Setting default FORWARD action to ACCEPT..."
+    iptables -P FORWARD ACCEPT
+
+    # Make sure ip_forward sysctl is set to allow ip forwarding.
+    sysctl -w net.ipv4.ip_forward=1
+
+    echo "Starting the flush Calico policy rules..."
+    echo "Make sure calico-node DaemonSet is stopped before this gets executed."
+
+    echo "Flushing all the calico iptables chains in the nat table..."
+    iptables-save -t nat | grep -oP '(?<!^:)cali-[^ ]+' | while read line; do iptables -t nat -F "$line"; done
+
+    echo "Flushing all the calico iptables chains in the raw table..."
+    iptables-save -t raw | grep -oP '(?<!^:)cali-[^ ]+' | while read line; do iptables -t raw -F "$line"; done
+
+    echo "Flushing all the calico iptables chains in the mangle table..."
+    iptables-save -t mangle | grep -oP '(?<!^:)cali-[^ ]+' | while read line; do iptables -t mangle -F "$line"; done
+
+    echo "Flushing all the calico iptables chains in the filter table..."
+    iptables-save -t filter | grep -oP '(?<!^:)cali-[^ ]+' | while read line; do iptables -t filter -F "$line"; done
+
+    echo "Cleaning up calico rules from the nat table..."
+    iptables-save -t nat | grep -e '--comment "cali:' | cut -c 3- | sed 's/^ *//;s/ *$//' | xargs -l1 iptables -t nat -D
+
+    echo "Cleaning up calico rules from the raw table..."
+    iptables-save -t raw | grep -e '--comment "cali:' | cut -c 3- | sed 's/^ *//;s/ *$//' | xargs -l1 iptables -t raw -D
+
+    echo "Cleaning up calico rules from the mangle table..."
+    iptables-save -t mangle | grep -e '--comment "cali:' | cut -c 3- | sed 's/^ *//;s/ *$//' | xargs -l1 iptables -t mangle -D
+
+    echo "Cleaning up calico rules from the filter table..."
+    iptables-save -t filter | grep -e '--comment "cali:' | cut -c 3- | sed 's/^ *//;s/ *$//' | xargs -l1 iptables -t filter -D
+}
+
+cleanup_felix

--- a/yamls/crd/crd.projectcalico.org_bgpconfigurations.yaml
+++ b/yamls/crd/crd.projectcalico.org_bgpconfigurations.yaml
@@ -1,0 +1,143 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: bgpconfigurations.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: BGPConfiguration
+    listKind: BGPConfigurationList
+    plural: bgpconfigurations
+    singular: bgpconfiguration
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: BGPConfiguration contains the configuration for any BGP routing.
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: BGPConfigurationSpec contains the values of the BGP configuration.
+              properties:
+                asNumber:
+                  description: 'ASNumber is the default AS number used by a node. [Default:
+                  64512]'
+                  format: int32
+                  type: integer
+                communities:
+                  description: Communities is a list of BGP community values and their
+                    arbitrary names for tagging routes.
+                  items:
+                    description: Community contains standard or large community value
+                      and its name.
+                    properties:
+                      name:
+                        description: Name given to community value.
+                        type: string
+                      value:
+                        description: Value must be of format `aa:nn` or `aa:nn:mm`.
+                          For standard community use `aa:nn` format, where `aa` and
+                          `nn` are 16 bit number. For large community use `aa:nn:mm`
+                          format, where `aa`, `nn` and `mm` are 32 bit number. Where,
+                          `aa` is an AS Number, `nn` and `mm` are per-AS identifier.
+                        pattern: ^(\d+):(\d+)$|^(\d+):(\d+):(\d+)$
+                        type: string
+                    type: object
+                  type: array
+                listenPort:
+                  description: ListenPort is the port where BGP protocol should listen.
+                    Defaults to 179
+                  maximum: 65535
+                  minimum: 1
+                  type: integer
+                logSeverityScreen:
+                  description: 'LogSeverityScreen is the log severity above which logs
+                  are sent to the stdout. [Default: INFO]'
+                  type: string
+                nodeToNodeMeshEnabled:
+                  description: 'NodeToNodeMeshEnabled sets whether full node to node
+                  BGP mesh is enabled. [Default: true]'
+                  type: boolean
+                prefixAdvertisements:
+                  description: PrefixAdvertisements contains per-prefix advertisement
+                    configuration.
+                  items:
+                    description: PrefixAdvertisement configures advertisement properties
+                      for the specified CIDR.
+                    properties:
+                      cidr:
+                        description: CIDR for which properties should be advertised.
+                        type: string
+                      communities:
+                        description: Communities can be list of either community names
+                          already defined in `Specs.Communities` or community value
+                          of format `aa:nn` or `aa:nn:mm`. For standard community use
+                          `aa:nn` format, where `aa` and `nn` are 16 bit number. For
+                          large community use `aa:nn:mm` format, where `aa`, `nn` and
+                          `mm` are 32 bit number. Where,`aa` is an AS Number, `nn` and
+                          `mm` are per-AS identifier.
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  type: array
+                serviceClusterIPs:
+                  description: ServiceClusterIPs are the CIDR blocks from which service
+                    cluster IPs are allocated. If specified, Calico will advertise these
+                    blocks, as well as any cluster IPs within them.
+                  items:
+                    description: ServiceClusterIPBlock represents a single allowed ClusterIP
+                      CIDR block.
+                    properties:
+                      cidr:
+                        type: string
+                    type: object
+                  type: array
+                serviceExternalIPs:
+                  description: ServiceExternalIPs are the CIDR blocks for Kubernetes
+                    Service External IPs. Kubernetes Service ExternalIPs will only be
+                    advertised if they are within one of these blocks.
+                  items:
+                    description: ServiceExternalIPBlock represents a single allowed
+                      External IP CIDR block.
+                    properties:
+                      cidr:
+                        type: string
+                    type: object
+                  type: array
+                serviceLoadBalancerIPs:
+                  description: ServiceLoadBalancerIPs are the CIDR blocks for Kubernetes
+                    Service LoadBalancer IPs. Kubernetes Service status.LoadBalancer.Ingress
+                    IPs will only be advertised if they are within one of these blocks.
+                  items:
+                    description: ServiceLoadBalancerIPBlock represents a single allowed
+                      LoadBalancer IP CIDR block.
+                    properties:
+                      cidr:
+                        type: string
+                    type: object
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/yamls/crd/crd.projectcalico.org_clusterinformations.yaml
+++ b/yamls/crd/crd.projectcalico.org_clusterinformations.yaml
@@ -1,0 +1,64 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: clusterinformations.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: ClusterInformation
+    listKind: ClusterInformationList
+    plural: clusterinformations
+    singular: clusterinformation
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: ClusterInformation contains the cluster specific information.
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ClusterInformationSpec contains the values of describing
+                the cluster.
+              properties:
+                calicoVersion:
+                  description: CalicoVersion is the version of Calico that the cluster
+                    is running
+                  type: string
+                clusterGUID:
+                  description: ClusterGUID is the GUID of the cluster
+                  type: string
+                clusterType:
+                  description: ClusterType describes the type of the cluster
+                  type: string
+                datastoreReady:
+                  description: DatastoreReady is used during significant datastore migrations
+                    to signal to components such as Felix that it should wait before
+                    accessing the datastore.
+                  type: boolean
+                variant:
+                  description: Variant declares which variant of Calico should be active.
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/yamls/crd/crd.projectcalico.org_felixconfigurations.yaml
+++ b/yamls/crd/crd.projectcalico.org_felixconfigurations.yaml
@@ -1,0 +1,564 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: felixconfigurations.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: FelixConfiguration
+    listKind: FelixConfigurationList
+    plural: felixconfigurations
+    singular: felixconfiguration
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: Felix Configuration contains the configuration for Felix.
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: FelixConfigurationSpec contains the values of the Felix configuration.
+              properties:
+                allowIPIPPacketsFromWorkloads:
+                  description: 'AllowIPIPPacketsFromWorkloads controls whether Felix
+                  will add a rule to drop IPIP encapsulated traffic from workloads
+                  [Default: false]'
+                  type: boolean
+                allowVXLANPacketsFromWorkloads:
+                  description: 'AllowVXLANPacketsFromWorkloads controls whether Felix
+                  will add a rule to drop VXLAN encapsulated traffic from workloads
+                  [Default: false]'
+                  type: boolean
+                awsSrcDstCheck:
+                  description: 'Set source-destination-check on AWS EC2 instances. Accepted
+                  value must be one of "DoNothing", "Enabled" or "Disabled". [Default:
+                  DoNothing]'
+                  enum:
+                    - DoNothing
+                    - Enable
+                    - Disable
+                  type: string
+                bpfConnectTimeLoadBalancingEnabled:
+                  description: 'BPFConnectTimeLoadBalancingEnabled when in BPF mode,
+                  controls whether Felix installs the connection-time load balancer.  The
+                  connect-time load balancer is required for the host to be able to
+                  reach Kubernetes services and it improves the performance of pod-to-service
+                  connections.  The only reason to disable it is for debugging purposes.  [Default:
+                  true]'
+                  type: boolean
+                bpfDataIfacePattern:
+                  description: BPFDataIfacePattern is a regular expression that controls
+                    which interfaces Felix should attach BPF programs to in order to
+                    catch traffic to/from the network.  This needs to match the interfaces
+                    that Calico workload traffic flows over as well as any interfaces
+                    that handle incoming traffic to nodeports and services from outside
+                    the cluster.  It should not match the workload interfaces (usually
+                    named cali...).
+                  type: string
+                bpfDisableUnprivileged:
+                  description: 'BPFDisableUnprivileged, if enabled, Felix sets the kernel.unprivileged_bpf_disabled
+                  sysctl to disable unprivileged use of BPF.  This ensures that unprivileged
+                  users cannot access Calico''s BPF maps and cannot insert their own
+                  BPF programs to interfere with Calico''s. [Default: true]'
+                  type: boolean
+                bpfEnabled:
+                  description: 'BPFEnabled, if enabled Felix will use the BPF dataplane.
+                  [Default: false]'
+                  type: boolean
+                bpfExternalServiceMode:
+                  description: 'BPFExternalServiceMode in BPF mode, controls how connections
+                  from outside the cluster to services (node ports and cluster IPs)
+                  are forwarded to remote workloads.  If set to "Tunnel" then both
+                  request and response traffic is tunneled to the remote node.  If
+                  set to "DSR", the request traffic is tunneled but the response traffic
+                  is sent directly from the remote node.  In "DSR" mode, the remote
+                  node appears to use the IP of the ingress node; this requires a
+                  permissive L2 network.  [Default: Tunnel]'
+                  type: string
+                bpfExtToServiceConnmark:
+                  description: 'BPFExtToServiceConnmark in BPF mode, controls a
+                  32bit mark that is set on connections from an external client to
+                  a local service. This mark allows us to control how packets of
+                  that connection are routed within the host and how is routing
+                  intepreted by RPF check. [Default: 0]'
+                  type: integer
+
+                bpfKubeProxyEndpointSlicesEnabled:
+                  description: BPFKubeProxyEndpointSlicesEnabled in BPF mode, controls
+                    whether Felix's embedded kube-proxy accepts EndpointSlices or not.
+                  type: boolean
+                bpfKubeProxyIptablesCleanupEnabled:
+                  description: 'BPFKubeProxyIptablesCleanupEnabled, if enabled in BPF
+                  mode, Felix will proactively clean up the upstream Kubernetes kube-proxy''s
+                  iptables chains.  Should only be enabled if kube-proxy is not running.  [Default:
+                  true]'
+                  type: boolean
+                bpfKubeProxyMinSyncPeriod:
+                  description: 'BPFKubeProxyMinSyncPeriod, in BPF mode, controls the
+                  minimum time between updates to the dataplane for Felix''s embedded
+                  kube-proxy.  Lower values give reduced set-up latency.  Higher values
+                  reduce Felix CPU usage by batching up more work.  [Default: 1s]'
+                  type: string
+                bpfLogLevel:
+                  description: 'BPFLogLevel controls the log level of the BPF programs
+                  when in BPF dataplane mode.  One of "Off", "Info", or "Debug".  The
+                  logs are emitted to the BPF trace pipe, accessible with the command
+                  `tc exec bpf debug`. [Default: Off].'
+                  type: string
+                chainInsertMode:
+                  description: 'ChainInsertMode controls whether Felix hooks the kernel''s
+                  top-level iptables chains by inserting a rule at the top of the
+                  chain or by appending a rule at the bottom. insert is the safe default
+                  since it prevents Calico''s rules from being bypassed. If you switch
+                  to append mode, be sure that the other rules in the chains signal
+                  acceptance by falling through to the Calico rules, otherwise the
+                  Calico policy will be bypassed. [Default: insert]'
+                  type: string
+                dataplaneDriver:
+                  type: string
+                debugDisableLogDropping:
+                  type: boolean
+                debugMemoryProfilePath:
+                  type: string
+                debugSimulateCalcGraphHangAfter:
+                  type: string
+                debugSimulateDataplaneHangAfter:
+                  type: string
+                defaultEndpointToHostAction:
+                  description: 'DefaultEndpointToHostAction controls what happens to
+                  traffic that goes from a workload endpoint to the host itself (after
+                  the traffic hits the endpoint egress policy). By default Calico
+                  blocks traffic from workload endpoints to the host itself with an
+                  iptables "DROP" action. If you want to allow some or all traffic
+                  from endpoint to host, set this parameter to RETURN or ACCEPT. Use
+                  RETURN if you have your own rules in the iptables "INPUT" chain;
+                  Calico will insert its rules at the top of that chain, then "RETURN"
+                  packets to the "INPUT" chain once it has completed processing workload
+                  endpoint egress policy. Use ACCEPT to unconditionally accept packets
+                  from workloads after processing workload endpoint egress policy.
+                  [Default: Drop]'
+                  type: string
+                deviceRouteProtocol:
+                  description: This defines the route protocol added to programmed device
+                    routes, by default this will be RTPROT_BOOT when left blank.
+                  type: integer
+                deviceRouteSourceAddress:
+                  description: This is the source address to use on programmed device
+                    routes. By default the source address is left blank, leaving the
+                    kernel to choose the source address used.
+                  type: string
+                disableConntrackInvalidCheck:
+                  type: boolean
+                endpointReportingDelay:
+                  type: string
+                endpointReportingEnabled:
+                  type: boolean
+                externalNodesList:
+                  description: ExternalNodesCIDRList is a list of CIDR's of external-non-calico-nodes
+                    which may source tunnel traffic and have the tunneled traffic be
+                    accepted at calico nodes.
+                  items:
+                    type: string
+                  type: array
+                failsafeInboundHostPorts:
+                  description: 'FailsafeInboundHostPorts is a list of UDP/TCP ports
+                  and CIDRs that Felix will allow incoming traffic to host endpoints
+                  on irrespective of the security policy. This is useful to avoid
+                  accidentally cutting off a host with incorrect configuration. For
+                  back-compatibility, if the protocol is not specified, it defaults
+                  to "tcp". If a CIDR is not specified, it will allow traffic from
+                  all addresses. To disable all inbound host ports, use the value
+                  none. The default value allows ssh access and DHCP. [Default: tcp:22,
+                  udp:68, tcp:179, tcp:2379, tcp:2380, tcp:6443, tcp:6666, tcp:6667]'
+                  items:
+                    description: ProtoPort is combination of protocol, port, and CIDR.
+                      Protocol and port must be specified.
+                    properties:
+                      net:
+                        type: string
+                      port:
+                        type: integer
+                      protocol:
+                        type: string
+                    required:
+                      - port
+                      - protocol
+                    type: object
+                  type: array
+                failsafeOutboundHostPorts:
+                  description: 'FailsafeOutboundHostPorts is a list of UDP/TCP ports
+                  and CIDRs that Felix will allow outgoing traffic from host endpoints
+                  to irrespective of the security policy. This is useful to avoid
+                  accidentally cutting off a host with incorrect configuration. For
+                  back-compatibility, if the protocol is not specified, it defaults
+                  to "tcp". If a CIDR is not specified, it will allow traffic from
+                  all addresses. To disable all outbound host ports, use the value
+                  none. The default value opens etcd''s standard ports to ensure that
+                  Felix does not get cut off from etcd as well as allowing DHCP and
+                  DNS. [Default: tcp:179, tcp:2379, tcp:2380, tcp:6443, tcp:6666,
+                  tcp:6667, udp:53, udp:67]'
+                  items:
+                    description: ProtoPort is combination of protocol, port, and CIDR.
+                      Protocol and port must be specified.
+                    properties:
+                      net:
+                        type: string
+                      port:
+                        type: integer
+                      protocol:
+                        type: string
+                    required:
+                      - port
+                      - protocol
+                    type: object
+                  type: array
+                featureDetectOverride:
+                  description: FeatureDetectOverride is used to override the feature
+                    detection. Values are specified in a comma separated list with no
+                    spaces, example; "SNATFullyRandom=true,MASQFullyRandom=false,RestoreSupportsLock=".
+                    "true" or "false" will force the feature, empty or omitted values
+                    are auto-detected.
+                  type: string
+                genericXDPEnabled:
+                  description: 'GenericXDPEnabled enables Generic XDP so network cards
+                  that don''t support XDP offload or driver modes can use XDP. This
+                  is not recommended since it doesn''t provide better performance
+                  than iptables. [Default: false]'
+                  type: boolean
+                healthEnabled:
+                  type: boolean
+                healthHost:
+                  type: string
+                healthPort:
+                  type: integer
+                interfaceExclude:
+                  description: 'InterfaceExclude is a comma-separated list of interfaces
+                  that Felix should exclude when monitoring for host endpoints. The
+                  default value ensures that Felix ignores Kubernetes'' IPVS dummy
+                  interface, which is used internally by kube-proxy. If you want to
+                  exclude multiple interface names using a single value, the list
+                  supports regular expressions. For regular expressions you must wrap
+                  the value with ''/''. For example having values ''/^kube/,veth1''
+                  will exclude all interfaces that begin with ''kube'' and also the
+                  interface ''veth1''. [Default: kube-ipvs0]'
+                  type: string
+                interfacePrefix:
+                  description: 'InterfacePrefix is the interface name prefix that identifies
+                  workload endpoints and so distinguishes them from host endpoint
+                  interfaces. Note: in environments other than bare metal, the orchestrators
+                  configure this appropriately. For example our Kubernetes and Docker
+                  integrations set the ''cali'' value, and our OpenStack integration
+                  sets the ''tap'' value. [Default: cali]'
+                  type: string
+                interfaceRefreshInterval:
+                  description: InterfaceRefreshInterval is the period at which Felix
+                    rescans local interfaces to verify their state. The rescan can be
+                    disabled by setting the interval to 0.
+                  type: string
+                ipipEnabled:
+                  type: boolean
+                ipipMTU:
+                  description: 'IPIPMTU is the MTU to set on the tunnel device. See
+                  Configuring MTU [Default: 1440]'
+                  type: integer
+                ipsetsRefreshInterval:
+                  description: 'IpsetsRefreshInterval is the period at which Felix re-checks
+                  all iptables state to ensure that no other process has accidentally
+                  broken Calico''s rules. Set to 0 to disable iptables refresh. [Default:
+                  90s]'
+                  type: string
+                iptablesBackend:
+                  description: IptablesBackend specifies which backend of iptables will
+                    be used. The default is legacy.
+                  type: string
+                iptablesFilterAllowAction:
+                  type: string
+                iptablesLockFilePath:
+                  description: 'IptablesLockFilePath is the location of the iptables
+                  lock file. You may need to change this if the lock file is not in
+                  its standard location (for example if you have mapped it into Felix''s
+                  container at a different path). [Default: /run/xtables.lock]'
+                  type: string
+                iptablesLockProbeInterval:
+                  description: 'IptablesLockProbeInterval is the time that Felix will
+                  wait between attempts to acquire the iptables lock if it is not
+                  available. Lower values make Felix more responsive when the lock
+                  is contended, but use more CPU. [Default: 50ms]'
+                  type: string
+                iptablesLockTimeout:
+                  description: 'IptablesLockTimeout is the time that Felix will wait
+                  for the iptables lock, or 0, to disable. To use this feature, Felix
+                  must share the iptables lock file with all other processes that
+                  also take the lock. When running Felix inside a container, this
+                  requires the /run directory of the host to be mounted into the calico/node
+                  or calico/felix container. [Default: 0s disabled]'
+                  type: string
+                iptablesMangleAllowAction:
+                  type: string
+                iptablesMarkMask:
+                  description: 'IptablesMarkMask is the mask that Felix selects its
+                  IPTables Mark bits from. Should be a 32 bit hexadecimal number with
+                  at least 8 bits set, none of which clash with any other mark bits
+                  in use on the system. [Default: 0xff000000]'
+                  format: int32
+                  type: integer
+                iptablesNATOutgoingInterfaceFilter:
+                  type: string
+                iptablesPostWriteCheckInterval:
+                  description: 'IptablesPostWriteCheckInterval is the period after Felix
+                  has done a write to the dataplane that it schedules an extra read
+                  back in order to check the write was not clobbered by another process.
+                  This should only occur if another application on the system doesn''t
+                  respect the iptables lock. [Default: 1s]'
+                  type: string
+                iptablesRefreshInterval:
+                  description: 'IptablesRefreshInterval is the period at which Felix
+                  re-checks the IP sets in the dataplane to ensure that no other process
+                  has accidentally broken Calico''s rules. Set to 0 to disable IP
+                  sets refresh. Note: the default for this value is lower than the
+                  other refresh intervals as a workaround for a Linux kernel bug that
+                  was fixed in kernel version 4.11. If you are using v4.11 or greater
+                  you may want to set this to, a higher value to reduce Felix CPU
+                  usage. [Default: 10s]'
+                  type: string
+                ipv6Support:
+                  type: boolean
+                kubeNodePortRanges:
+                  description: 'KubeNodePortRanges holds list of port ranges used for
+                  service node ports. Only used if felix detects kube-proxy running
+                  in ipvs mode. Felix uses these ranges to separate host and workload
+                  traffic. [Default: 30000:32767].'
+                  items:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^.*
+                    x-kubernetes-int-or-string: true
+                  type: array
+                logFilePath:
+                  description: 'LogFilePath is the full path to the Felix log. Set to
+                  none to disable file logging. [Default: /var/log/calico/felix.log]'
+                  type: string
+                logPrefix:
+                  description: 'LogPrefix is the log prefix that Felix uses when rendering
+                  LOG rules. [Default: calico-packet]'
+                  type: string
+                logSeverityFile:
+                  description: 'LogSeverityFile is the log severity above which logs
+                  are sent to the log file. [Default: Info]'
+                  type: string
+                logSeverityScreen:
+                  description: 'LogSeverityScreen is the log severity above which logs
+                  are sent to the stdout. [Default: Info]'
+                  type: string
+                logSeveritySys:
+                  description: 'LogSeveritySys is the log severity above which logs
+                  are sent to the syslog. Set to None for no logging to syslog. [Default:
+                  Info]'
+                  type: string
+                maxIpsetSize:
+                  type: integer
+                metadataAddr:
+                  description: 'MetadataAddr is the IP address or domain name of the
+                  server that can answer VM queries for cloud-init metadata. In OpenStack,
+                  this corresponds to the machine running nova-api (or in Ubuntu,
+                  nova-api-metadata). A value of none (case insensitive) means that
+                  Felix should not set up any NAT rule for the metadata path. [Default:
+                  127.0.0.1]'
+                  type: string
+                metadataPort:
+                  description: 'MetadataPort is the port of the metadata server. This,
+                  combined with global.MetadataAddr (if not ''None''), is used to
+                  set up a NAT rule, from 169.254.169.254:80 to MetadataAddr:MetadataPort.
+                  In most cases this should not need to be changed [Default: 8775].'
+                  type: integer
+                mtuIfacePattern:
+                  description: MTUIfacePattern is a regular expression that controls
+                    which interfaces Felix should scan in order to calculate the host's
+                    MTU. This should not match workload interfaces (usually named cali...).
+                  type: string
+                natOutgoingAddress:
+                  description: NATOutgoingAddress specifies an address to use when performing
+                    source NAT for traffic in a natOutgoing pool that is leaving the
+                    network. By default the address used is an address on the interface
+                    the traffic is leaving on (ie it uses the iptables MASQUERADE target)
+                  type: string
+                natPortRange:
+                  anyOf:
+                    - type: integer
+                    - type: string
+                  description: NATPortRange specifies the range of ports that is used
+                    for port mapping when doing outgoing NAT. When unset the default
+                    behavior of the network stack is used.
+                  pattern: ^.*
+                  x-kubernetes-int-or-string: true
+                netlinkTimeout:
+                  type: string
+                openstackRegion:
+                  description: 'OpenstackRegion is the name of the region that a particular
+                  Felix belongs to. In a multi-region Calico/OpenStack deployment,
+                  this must be configured somehow for each Felix (here in the datamodel,
+                  or in felix.cfg or the environment on each compute node), and must
+                  match the [calico] openstack_region value configured in neutron.conf
+                  on each node. [Default: Empty]'
+                  type: string
+                policySyncPathPrefix:
+                  description: 'PolicySyncPathPrefix is used to by Felix to communicate
+                  policy changes to external services, like Application layer policy.
+                  [Default: Empty]'
+                  type: string
+                prometheusGoMetricsEnabled:
+                  description: 'PrometheusGoMetricsEnabled disables Go runtime metrics
+                  collection, which the Prometheus client does by default, when set
+                  to false. This reduces the number of metrics reported, reducing
+                  Prometheus load. [Default: true]'
+                  type: boolean
+                prometheusMetricsEnabled:
+                  description: 'PrometheusMetricsEnabled enables the Prometheus metrics
+                  server in Felix if set to true. [Default: false]'
+                  type: boolean
+                prometheusMetricsHost:
+                  description: 'PrometheusMetricsHost is the host that the Prometheus
+                  metrics server should bind to. [Default: empty]'
+                  type: string
+                prometheusMetricsPort:
+                  description: 'PrometheusMetricsPort is the TCP port that the Prometheus
+                  metrics server should bind to. [Default: 9091]'
+                  type: integer
+                prometheusProcessMetricsEnabled:
+                  description: 'PrometheusProcessMetricsEnabled disables process metrics
+                  collection, which the Prometheus client does by default, when set
+                  to false. This reduces the number of metrics reported, reducing
+                  Prometheus load. [Default: true]'
+                  type: boolean
+                removeExternalRoutes:
+                  description: Whether or not to remove device routes that have not
+                    been programmed by Felix. Disabling this will allow external applications
+                    to also add device routes. This is enabled by default which means
+                    we will remove externally added routes.
+                  type: boolean
+                reportingInterval:
+                  description: 'ReportingInterval is the interval at which Felix reports
+                  its status into the datastore or 0 to disable. Must be non-zero
+                  in OpenStack deployments. [Default: 30s]'
+                  type: string
+                reportingTTL:
+                  description: 'ReportingTTL is the time-to-live setting for process-wide
+                  status reports. [Default: 90s]'
+                  type: string
+                routeRefreshInterval:
+                  description: 'RouteRefreshInterval is the period at which Felix re-checks
+                  the routes in the dataplane to ensure that no other process has
+                  accidentally broken Calico''s rules. Set to 0 to disable route refresh.
+                  [Default: 90s]'
+                  type: string
+                routeSource:
+                  description: 'RouteSource configures where Felix gets its routing
+                  information. - WorkloadIPs: use workload endpoints to construct
+                  routes. - CalicoIPAM: the default - use IPAM data to construct routes.'
+                  type: string
+                routeTableRange:
+                  description: Calico programs additional Linux route tables for various
+                    purposes.  RouteTableRange specifies the indices of the route tables
+                    that Calico should use.
+                  properties:
+                    max:
+                      type: integer
+                    min:
+                      type: integer
+                  required:
+                    - max
+                    - min
+                  type: object
+                serviceLoopPrevention:
+                  description: 'When service IP advertisement is enabled, prevent routing
+                  loops to service IPs that are not in use, by dropping or rejecting
+                  packets that do not get DNAT''d by kube-proxy. Unless set to "Disabled",
+                  in which case such routing loops continue to be allowed. [Default:
+                  Drop]'
+                  type: string
+                sidecarAccelerationEnabled:
+                  description: 'SidecarAccelerationEnabled enables experimental sidecar
+                  acceleration [Default: false]'
+                  type: boolean
+                usageReportingEnabled:
+                  description: 'UsageReportingEnabled reports anonymous Calico version
+                  number and cluster size to projectcalico.org. Logs warnings returned
+                  by the usage server. For example, if a significant security vulnerability
+                  has been discovered in the version of Calico being used. [Default:
+                  true]'
+                  type: boolean
+                usageReportingInitialDelay:
+                  description: 'UsageReportingInitialDelay controls the minimum delay
+                  before Felix makes a report. [Default: 300s]'
+                  type: string
+                usageReportingInterval:
+                  description: 'UsageReportingInterval controls the interval at which
+                  Felix makes reports. [Default: 86400s]'
+                  type: string
+                useInternalDataplaneDriver:
+                  type: boolean
+                vxlanEnabled:
+                  type: boolean
+                vxlanMTU:
+                  description: 'VXLANMTU is the MTU to set on the tunnel device. See
+                  Configuring MTU [Default: 1440]'
+                  type: integer
+                vxlanPort:
+                  type: integer
+                vxlanVNI:
+                  type: integer
+                wireguardEnabled:
+                  description: 'WireguardEnabled controls whether Wireguard is enabled.
+                  [Default: false]'
+                  type: boolean
+                wireguardInterfaceName:
+                  description: 'WireguardInterfaceName specifies the name to use for
+                  the Wireguard interface. [Default: wg.calico]'
+                  type: string
+                wireguardListeningPort:
+                  description: 'WireguardListeningPort controls the listening port used
+                  by Wireguard. [Default: 51820]'
+                  type: integer
+                wireguardMTU:
+                  description: 'WireguardMTU controls the MTU on the Wireguard interface.
+                  See Configuring MTU [Default: 1420]'
+                  type: integer
+                wireguardRoutingRulePriority:
+                  description: 'WireguardRoutingRulePriority controls the priority value
+                  to use for the Wireguard routing rule. [Default: 99]'
+                  type: integer
+                xdpEnabled:
+                  description: 'XDPEnabled enables XDP acceleration for suitable untracked
+                  incoming deny rules. [Default: true]'
+                  type: boolean
+                xdpRefreshInterval:
+                  description: 'XDPRefreshInterval is the period at which Felix re-checks
+                  all XDP state to ensure that no other process has accidentally broken
+                  Calico''s BPF maps or attached programs. Set to 0 to disable XDP
+                  refresh. [Default: 90s]'
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/yamls/crd/crd.projectcalico.org_globalnetworkpolicies.yaml
+++ b/yamls/crd/crd.projectcalico.org_globalnetworkpolicies.yaml
@@ -1,0 +1,855 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: globalnetworkpolicies.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: GlobalNetworkPolicy
+    listKind: GlobalNetworkPolicyList
+    plural: globalnetworkpolicies
+    singular: globalnetworkpolicy
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                applyOnForward:
+                  description: ApplyOnForward indicates to apply the rules in this policy
+                    on forward traffic.
+                  type: boolean
+                doNotTrack:
+                  description: DoNotTrack indicates whether packets matched by the rules
+                    in this policy should go through the data plane's connection tracking,
+                    such as Linux conntrack.  If True, the rules in this policy are
+                    applied before any data plane connection tracking, and packets allowed
+                    by this policy are marked as not to be tracked.
+                  type: boolean
+                egress:
+                  description: The ordered set of egress rules.  Each rule contains
+                    a set of packet match criteria and a corresponding action to apply.
+                  items:
+                    description: "A Rule encapsulates a set of match criteria and an
+                    action.  Both selector-based security Policy and security Profiles
+                    reference rules - separated out as a list of rules for both ingress
+                    and egress packet matching. \n Each positive match criteria has
+                    a negated version, prefixed with \"Not\". All the match criteria
+                    within a rule must be satisfied for a packet to match. A single
+                    rule can contain the positive and negative version of a match
+                    and both must be satisfied for the rule to match."
+                    properties:
+                      action:
+                        type: string
+                      destination:
+                        description: Destination contains the match criteria that apply
+                          to destination entity.
+                        properties:
+                          namespaceSelector:
+                            description: "NamespaceSelector is an optional field that
+                            contains a selector expression. Only traffic that originates
+                            from (or terminates at) endpoints within the selected
+                            namespaces will be matched. When both NamespaceSelector
+                            and another selector are defined on the same rule, then
+                            only workload endpoints that are matched by both selectors
+                            will be selected by the rule. \n For NetworkPolicy, an
+                            empty NamespaceSelector implies that the Selector is limited
+                            to selecting only workload endpoints in the same namespace
+                            as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                            NamespaceSelector implies that the Selector is limited
+                            to selecting only GlobalNetworkSet or HostEndpoint. \n
+                            For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                            the Selector applies to workload endpoints across all
+                            namespaces."
+                            type: string
+                          nets:
+                            description: Nets is an optional field that restricts the
+                              rule to only apply to traffic that originates from (or
+                              terminates at) IP addresses in any of the given subnets.
+                            items:
+                              type: string
+                            type: array
+                          notNets:
+                            description: NotNets is the negated version of the Nets
+                              field.
+                            items:
+                              type: string
+                            type: array
+                          notPorts:
+                            description: NotPorts is the negated version of the Ports
+                              field. Since only some protocols have ports, if any ports
+                              are specified it requires the Protocol match in the Rule
+                              to be set to "TCP" or "UDP".
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          notSelector:
+                            description: NotSelector is the negated version of the Selector
+                              field.  See Selector field for subtleties with negated
+                              selectors.
+                            type: string
+                          ports:
+                            description: "Ports is an optional field that restricts
+                            the rule to only apply to traffic that has a source (destination)
+                            port that matches one of these ranges/values. This value
+                            is a list of integers or strings that represent ranges
+                            of ports. \n Since only some protocols have ports, if
+                            any ports are specified it requires the Protocol match
+                            in the Rule to be set to \"TCP\" or \"UDP\"."
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          selector:
+                            description: "Selector is an optional field that contains
+                            a selector expression (see Policy for sample syntax).
+                            \ Only traffic that originates from (terminates at) endpoints
+                            matching the selector will be matched. \n Note that: in
+                            addition to the negated version of the Selector (see NotSelector
+                            below), the selector expression syntax itself supports
+                            negation.  The two types of negation are subtly different.
+                            One negates the set of matched endpoints, the other negates
+                            the whole match: \n \tSelector = \"!has(my_label)\" matches
+                            packets that are from other Calico-controlled \tendpoints
+                            that do not have the label \"my_label\". \n \tNotSelector
+                            = \"has(my_label)\" matches packets that are not from
+                            Calico-controlled \tendpoints that do have the label \"my_label\".
+                            \n The effect is that the latter will accept packets from
+                            non-Calico sources whereas the former is limited to packets
+                            from Calico-controlled endpoints."
+                            type: string
+                          serviceAccounts:
+                            description: ServiceAccounts is an optional field that restricts
+                              the rule to only apply to traffic that originates from
+                              (or terminates at) a pod running as a matching service
+                              account.
+                            properties:
+                              names:
+                                description: Names is an optional field that restricts
+                                  the rule to only apply to traffic that originates
+                                  from (or terminates at) a pod running as a service
+                                  account whose name is in the list.
+                                items:
+                                  type: string
+                                type: array
+                              selector:
+                                description: Selector is an optional field that restricts
+                                  the rule to only apply to traffic that originates
+                                  from (or terminates at) a pod running as a service
+                                  account that matches the given label selector. If
+                                  both Names and Selector are specified then they are
+                                  AND'ed.
+                                type: string
+                            type: object
+                          services:
+                            description: "Services is an optional field that contains
+                            options for matching Kubernetes Services. If specified,
+                            only traffic that originates from or terminates at endpoints
+                            within the selected service(s) will be matched, and only
+                            to/from each endpoint's port. \n Services cannot be specified
+                            on the same rule as Selector, NotSelector, NamespaceSelector,
+                            Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                            Only valid on egress rules."
+                            properties:
+                              name:
+                                description: Name specifies the name of a Kubernetes
+                                  Service to match.
+                                type: string
+                              namespace:
+                                description: Namespace specifies the namespace of the
+                                  given Service. If left empty, the rule will match
+                                  within this policy's namespace.
+                                type: string
+                            type: object
+                        type: object
+                      http:
+                        description: HTTP contains match criteria that apply to HTTP
+                          requests.
+                        properties:
+                          methods:
+                            description: Methods is an optional field that restricts
+                              the rule to apply only to HTTP requests that use one of
+                              the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
+                              methods are OR'd together.
+                            items:
+                              type: string
+                            type: array
+                          paths:
+                            description: 'Paths is an optional field that restricts
+                            the rule to apply to HTTP requests that use one of the
+                            listed HTTP Paths. Multiple paths are OR''d together.
+                            e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
+                            ONLY specify either a `exact` or a `prefix` match. The
+                            validator will check for it.'
+                            items:
+                              description: 'HTTPPath specifies an HTTP path to match.
+                              It may be either of the form: exact: <path>: which matches
+                              the path exactly or prefix: <path-prefix>: which matches
+                              the path prefix'
+                              properties:
+                                exact:
+                                  type: string
+                                prefix:
+                                  type: string
+                              type: object
+                            type: array
+                        type: object
+                      icmp:
+                        description: ICMP is an optional field that restricts the rule
+                          to apply to a specific type and code of ICMP traffic.  This
+                          should only be specified if the Protocol field is set to "ICMP"
+                          or "ICMPv6".
+                        properties:
+                          code:
+                            description: Match on a specific ICMP code.  If specified,
+                              the Type value must also be specified. This is a technical
+                              limitation imposed by the kernel's iptables firewall,
+                              which Calico uses to enforce the rule.
+                            type: integer
+                          type:
+                            description: Match on a specific ICMP type.  For example
+                              a value of 8 refers to ICMP Echo Request (i.e. pings).
+                            type: integer
+                        type: object
+                      ipVersion:
+                        description: IPVersion is an optional field that restricts the
+                          rule to only match a specific IP version.
+                        type: integer
+                      metadata:
+                        description: Metadata contains additional information for this
+                          rule
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            description: Annotations is a set of key value pairs that
+                              give extra information about the rule
+                            type: object
+                        type: object
+                      notICMP:
+                        description: NotICMP is the negated version of the ICMP field.
+                        properties:
+                          code:
+                            description: Match on a specific ICMP code.  If specified,
+                              the Type value must also be specified. This is a technical
+                              limitation imposed by the kernel's iptables firewall,
+                              which Calico uses to enforce the rule.
+                            type: integer
+                          type:
+                            description: Match on a specific ICMP type.  For example
+                              a value of 8 refers to ICMP Echo Request (i.e. pings).
+                            type: integer
+                        type: object
+                      notProtocol:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        description: NotProtocol is the negated version of the Protocol
+                          field.
+                        pattern: ^.*
+                        x-kubernetes-int-or-string: true
+                      protocol:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        description: "Protocol is an optional field that restricts the
+                        rule to only apply to traffic of a specific IP protocol. Required
+                        if any of the EntityRules contain Ports (because ports only
+                        apply to certain protocols). \n Must be one of these string
+                        values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
+                        \"UDPLite\" or an integer in the range 1-255."
+                        pattern: ^.*
+                        x-kubernetes-int-or-string: true
+                      source:
+                        description: Source contains the match criteria that apply to
+                          source entity.
+                        properties:
+                          namespaceSelector:
+                            description: "NamespaceSelector is an optional field that
+                            contains a selector expression. Only traffic that originates
+                            from (or terminates at) endpoints within the selected
+                            namespaces will be matched. When both NamespaceSelector
+                            and another selector are defined on the same rule, then
+                            only workload endpoints that are matched by both selectors
+                            will be selected by the rule. \n For NetworkPolicy, an
+                            empty NamespaceSelector implies that the Selector is limited
+                            to selecting only workload endpoints in the same namespace
+                            as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                            NamespaceSelector implies that the Selector is limited
+                            to selecting only GlobalNetworkSet or HostEndpoint. \n
+                            For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                            the Selector applies to workload endpoints across all
+                            namespaces."
+                            type: string
+                          nets:
+                            description: Nets is an optional field that restricts the
+                              rule to only apply to traffic that originates from (or
+                              terminates at) IP addresses in any of the given subnets.
+                            items:
+                              type: string
+                            type: array
+                          notNets:
+                            description: NotNets is the negated version of the Nets
+                              field.
+                            items:
+                              type: string
+                            type: array
+                          notPorts:
+                            description: NotPorts is the negated version of the Ports
+                              field. Since only some protocols have ports, if any ports
+                              are specified it requires the Protocol match in the Rule
+                              to be set to "TCP" or "UDP".
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          notSelector:
+                            description: NotSelector is the negated version of the Selector
+                              field.  See Selector field for subtleties with negated
+                              selectors.
+                            type: string
+                          ports:
+                            description: "Ports is an optional field that restricts
+                            the rule to only apply to traffic that has a source (destination)
+                            port that matches one of these ranges/values. This value
+                            is a list of integers or strings that represent ranges
+                            of ports. \n Since only some protocols have ports, if
+                            any ports are specified it requires the Protocol match
+                            in the Rule to be set to \"TCP\" or \"UDP\"."
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          selector:
+                            description: "Selector is an optional field that contains
+                            a selector expression (see Policy for sample syntax).
+                            \ Only traffic that originates from (terminates at) endpoints
+                            matching the selector will be matched. \n Note that: in
+                            addition to the negated version of the Selector (see NotSelector
+                            below), the selector expression syntax itself supports
+                            negation.  The two types of negation are subtly different.
+                            One negates the set of matched endpoints, the other negates
+                            the whole match: \n \tSelector = \"!has(my_label)\" matches
+                            packets that are from other Calico-controlled \tendpoints
+                            that do not have the label \"my_label\". \n \tNotSelector
+                            = \"has(my_label)\" matches packets that are not from
+                            Calico-controlled \tendpoints that do have the label \"my_label\".
+                            \n The effect is that the latter will accept packets from
+                            non-Calico sources whereas the former is limited to packets
+                            from Calico-controlled endpoints."
+                            type: string
+                          serviceAccounts:
+                            description: ServiceAccounts is an optional field that restricts
+                              the rule to only apply to traffic that originates from
+                              (or terminates at) a pod running as a matching service
+                              account.
+                            properties:
+                              names:
+                                description: Names is an optional field that restricts
+                                  the rule to only apply to traffic that originates
+                                  from (or terminates at) a pod running as a service
+                                  account whose name is in the list.
+                                items:
+                                  type: string
+                                type: array
+                              selector:
+                                description: Selector is an optional field that restricts
+                                  the rule to only apply to traffic that originates
+                                  from (or terminates at) a pod running as a service
+                                  account that matches the given label selector. If
+                                  both Names and Selector are specified then they are
+                                  AND'ed.
+                                type: string
+                            type: object
+                          services:
+                            description: "Services is an optional field that contains
+                            options for matching Kubernetes Services. If specified,
+                            only traffic that originates from or terminates at endpoints
+                            within the selected service(s) will be matched, and only
+                            to/from each endpoint's port. \n Services cannot be specified
+                            on the same rule as Selector, NotSelector, NamespaceSelector,
+                            Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                            Only valid on egress rules."
+                            properties:
+                              name:
+                                description: Name specifies the name of a Kubernetes
+                                  Service to match.
+                                type: string
+                              namespace:
+                                description: Namespace specifies the namespace of the
+                                  given Service. If left empty, the rule will match
+                                  within this policy's namespace.
+                                type: string
+                            type: object
+                        type: object
+                    required:
+                      - action
+                    type: object
+                  type: array
+                ingress:
+                  description: The ordered set of ingress rules.  Each rule contains
+                    a set of packet match criteria and a corresponding action to apply.
+                  items:
+                    description: "A Rule encapsulates a set of match criteria and an
+                    action.  Both selector-based security Policy and security Profiles
+                    reference rules - separated out as a list of rules for both ingress
+                    and egress packet matching. \n Each positive match criteria has
+                    a negated version, prefixed with \"Not\". All the match criteria
+                    within a rule must be satisfied for a packet to match. A single
+                    rule can contain the positive and negative version of a match
+                    and both must be satisfied for the rule to match."
+                    properties:
+                      action:
+                        type: string
+                      destination:
+                        description: Destination contains the match criteria that apply
+                          to destination entity.
+                        properties:
+                          namespaceSelector:
+                            description: "NamespaceSelector is an optional field that
+                            contains a selector expression. Only traffic that originates
+                            from (or terminates at) endpoints within the selected
+                            namespaces will be matched. When both NamespaceSelector
+                            and another selector are defined on the same rule, then
+                            only workload endpoints that are matched by both selectors
+                            will be selected by the rule. \n For NetworkPolicy, an
+                            empty NamespaceSelector implies that the Selector is limited
+                            to selecting only workload endpoints in the same namespace
+                            as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                            NamespaceSelector implies that the Selector is limited
+                            to selecting only GlobalNetworkSet or HostEndpoint. \n
+                            For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                            the Selector applies to workload endpoints across all
+                            namespaces."
+                            type: string
+                          nets:
+                            description: Nets is an optional field that restricts the
+                              rule to only apply to traffic that originates from (or
+                              terminates at) IP addresses in any of the given subnets.
+                            items:
+                              type: string
+                            type: array
+                          notNets:
+                            description: NotNets is the negated version of the Nets
+                              field.
+                            items:
+                              type: string
+                            type: array
+                          notPorts:
+                            description: NotPorts is the negated version of the Ports
+                              field. Since only some protocols have ports, if any ports
+                              are specified it requires the Protocol match in the Rule
+                              to be set to "TCP" or "UDP".
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          notSelector:
+                            description: NotSelector is the negated version of the Selector
+                              field.  See Selector field for subtleties with negated
+                              selectors.
+                            type: string
+                          ports:
+                            description: "Ports is an optional field that restricts
+                            the rule to only apply to traffic that has a source (destination)
+                            port that matches one of these ranges/values. This value
+                            is a list of integers or strings that represent ranges
+                            of ports. \n Since only some protocols have ports, if
+                            any ports are specified it requires the Protocol match
+                            in the Rule to be set to \"TCP\" or \"UDP\"."
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          selector:
+                            description: "Selector is an optional field that contains
+                            a selector expression (see Policy for sample syntax).
+                            \ Only traffic that originates from (terminates at) endpoints
+                            matching the selector will be matched. \n Note that: in
+                            addition to the negated version of the Selector (see NotSelector
+                            below), the selector expression syntax itself supports
+                            negation.  The two types of negation are subtly different.
+                            One negates the set of matched endpoints, the other negates
+                            the whole match: \n \tSelector = \"!has(my_label)\" matches
+                            packets that are from other Calico-controlled \tendpoints
+                            that do not have the label \"my_label\". \n \tNotSelector
+                            = \"has(my_label)\" matches packets that are not from
+                            Calico-controlled \tendpoints that do have the label \"my_label\".
+                            \n The effect is that the latter will accept packets from
+                            non-Calico sources whereas the former is limited to packets
+                            from Calico-controlled endpoints."
+                            type: string
+                          serviceAccounts:
+                            description: ServiceAccounts is an optional field that restricts
+                              the rule to only apply to traffic that originates from
+                              (or terminates at) a pod running as a matching service
+                              account.
+                            properties:
+                              names:
+                                description: Names is an optional field that restricts
+                                  the rule to only apply to traffic that originates
+                                  from (or terminates at) a pod running as a service
+                                  account whose name is in the list.
+                                items:
+                                  type: string
+                                type: array
+                              selector:
+                                description: Selector is an optional field that restricts
+                                  the rule to only apply to traffic that originates
+                                  from (or terminates at) a pod running as a service
+                                  account that matches the given label selector. If
+                                  both Names and Selector are specified then they are
+                                  AND'ed.
+                                type: string
+                            type: object
+                          services:
+                            description: "Services is an optional field that contains
+                            options for matching Kubernetes Services. If specified,
+                            only traffic that originates from or terminates at endpoints
+                            within the selected service(s) will be matched, and only
+                            to/from each endpoint's port. \n Services cannot be specified
+                            on the same rule as Selector, NotSelector, NamespaceSelector,
+                            Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                            Only valid on egress rules."
+                            properties:
+                              name:
+                                description: Name specifies the name of a Kubernetes
+                                  Service to match.
+                                type: string
+                              namespace:
+                                description: Namespace specifies the namespace of the
+                                  given Service. If left empty, the rule will match
+                                  within this policy's namespace.
+                                type: string
+                            type: object
+                        type: object
+                      http:
+                        description: HTTP contains match criteria that apply to HTTP
+                          requests.
+                        properties:
+                          methods:
+                            description: Methods is an optional field that restricts
+                              the rule to apply only to HTTP requests that use one of
+                              the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
+                              methods are OR'd together.
+                            items:
+                              type: string
+                            type: array
+                          paths:
+                            description: 'Paths is an optional field that restricts
+                            the rule to apply to HTTP requests that use one of the
+                            listed HTTP Paths. Multiple paths are OR''d together.
+                            e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
+                            ONLY specify either a `exact` or a `prefix` match. The
+                            validator will check for it.'
+                            items:
+                              description: 'HTTPPath specifies an HTTP path to match.
+                              It may be either of the form: exact: <path>: which matches
+                              the path exactly or prefix: <path-prefix>: which matches
+                              the path prefix'
+                              properties:
+                                exact:
+                                  type: string
+                                prefix:
+                                  type: string
+                              type: object
+                            type: array
+                        type: object
+                      icmp:
+                        description: ICMP is an optional field that restricts the rule
+                          to apply to a specific type and code of ICMP traffic.  This
+                          should only be specified if the Protocol field is set to "ICMP"
+                          or "ICMPv6".
+                        properties:
+                          code:
+                            description: Match on a specific ICMP code.  If specified,
+                              the Type value must also be specified. This is a technical
+                              limitation imposed by the kernel's iptables firewall,
+                              which Calico uses to enforce the rule.
+                            type: integer
+                          type:
+                            description: Match on a specific ICMP type.  For example
+                              a value of 8 refers to ICMP Echo Request (i.e. pings).
+                            type: integer
+                        type: object
+                      ipVersion:
+                        description: IPVersion is an optional field that restricts the
+                          rule to only match a specific IP version.
+                        type: integer
+                      metadata:
+                        description: Metadata contains additional information for this
+                          rule
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            description: Annotations is a set of key value pairs that
+                              give extra information about the rule
+                            type: object
+                        type: object
+                      notICMP:
+                        description: NotICMP is the negated version of the ICMP field.
+                        properties:
+                          code:
+                            description: Match on a specific ICMP code.  If specified,
+                              the Type value must also be specified. This is a technical
+                              limitation imposed by the kernel's iptables firewall,
+                              which Calico uses to enforce the rule.
+                            type: integer
+                          type:
+                            description: Match on a specific ICMP type.  For example
+                              a value of 8 refers to ICMP Echo Request (i.e. pings).
+                            type: integer
+                        type: object
+                      notProtocol:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        description: NotProtocol is the negated version of the Protocol
+                          field.
+                        pattern: ^.*
+                        x-kubernetes-int-or-string: true
+                      protocol:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        description: "Protocol is an optional field that restricts the
+                        rule to only apply to traffic of a specific IP protocol. Required
+                        if any of the EntityRules contain Ports (because ports only
+                        apply to certain protocols). \n Must be one of these string
+                        values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
+                        \"UDPLite\" or an integer in the range 1-255."
+                        pattern: ^.*
+                        x-kubernetes-int-or-string: true
+                      source:
+                        description: Source contains the match criteria that apply to
+                          source entity.
+                        properties:
+                          namespaceSelector:
+                            description: "NamespaceSelector is an optional field that
+                            contains a selector expression. Only traffic that originates
+                            from (or terminates at) endpoints within the selected
+                            namespaces will be matched. When both NamespaceSelector
+                            and another selector are defined on the same rule, then
+                            only workload endpoints that are matched by both selectors
+                            will be selected by the rule. \n For NetworkPolicy, an
+                            empty NamespaceSelector implies that the Selector is limited
+                            to selecting only workload endpoints in the same namespace
+                            as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                            NamespaceSelector implies that the Selector is limited
+                            to selecting only GlobalNetworkSet or HostEndpoint. \n
+                            For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                            the Selector applies to workload endpoints across all
+                            namespaces."
+                            type: string
+                          nets:
+                            description: Nets is an optional field that restricts the
+                              rule to only apply to traffic that originates from (or
+                              terminates at) IP addresses in any of the given subnets.
+                            items:
+                              type: string
+                            type: array
+                          notNets:
+                            description: NotNets is the negated version of the Nets
+                              field.
+                            items:
+                              type: string
+                            type: array
+                          notPorts:
+                            description: NotPorts is the negated version of the Ports
+                              field. Since only some protocols have ports, if any ports
+                              are specified it requires the Protocol match in the Rule
+                              to be set to "TCP" or "UDP".
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          notSelector:
+                            description: NotSelector is the negated version of the Selector
+                              field.  See Selector field for subtleties with negated
+                              selectors.
+                            type: string
+                          ports:
+                            description: "Ports is an optional field that restricts
+                            the rule to only apply to traffic that has a source (destination)
+                            port that matches one of these ranges/values. This value
+                            is a list of integers or strings that represent ranges
+                            of ports. \n Since only some protocols have ports, if
+                            any ports are specified it requires the Protocol match
+                            in the Rule to be set to \"TCP\" or \"UDP\"."
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          selector:
+                            description: "Selector is an optional field that contains
+                            a selector expression (see Policy for sample syntax).
+                            \ Only traffic that originates from (terminates at) endpoints
+                            matching the selector will be matched. \n Note that: in
+                            addition to the negated version of the Selector (see NotSelector
+                            below), the selector expression syntax itself supports
+                            negation.  The two types of negation are subtly different.
+                            One negates the set of matched endpoints, the other negates
+                            the whole match: \n \tSelector = \"!has(my_label)\" matches
+                            packets that are from other Calico-controlled \tendpoints
+                            that do not have the label \"my_label\". \n \tNotSelector
+                            = \"has(my_label)\" matches packets that are not from
+                            Calico-controlled \tendpoints that do have the label \"my_label\".
+                            \n The effect is that the latter will accept packets from
+                            non-Calico sources whereas the former is limited to packets
+                            from Calico-controlled endpoints."
+                            type: string
+                          serviceAccounts:
+                            description: ServiceAccounts is an optional field that restricts
+                              the rule to only apply to traffic that originates from
+                              (or terminates at) a pod running as a matching service
+                              account.
+                            properties:
+                              names:
+                                description: Names is an optional field that restricts
+                                  the rule to only apply to traffic that originates
+                                  from (or terminates at) a pod running as a service
+                                  account whose name is in the list.
+                                items:
+                                  type: string
+                                type: array
+                              selector:
+                                description: Selector is an optional field that restricts
+                                  the rule to only apply to traffic that originates
+                                  from (or terminates at) a pod running as a service
+                                  account that matches the given label selector. If
+                                  both Names and Selector are specified then they are
+                                  AND'ed.
+                                type: string
+                            type: object
+                          services:
+                            description: "Services is an optional field that contains
+                            options for matching Kubernetes Services. If specified,
+                            only traffic that originates from or terminates at endpoints
+                            within the selected service(s) will be matched, and only
+                            to/from each endpoint's port. \n Services cannot be specified
+                            on the same rule as Selector, NotSelector, NamespaceSelector,
+                            Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                            Only valid on egress rules."
+                            properties:
+                              name:
+                                description: Name specifies the name of a Kubernetes
+                                  Service to match.
+                                type: string
+                              namespace:
+                                description: Namespace specifies the namespace of the
+                                  given Service. If left empty, the rule will match
+                                  within this policy's namespace.
+                                type: string
+                            type: object
+                        type: object
+                    required:
+                      - action
+                    type: object
+                  type: array
+                namespaceSelector:
+                  description: NamespaceSelector is an optional field for an expression
+                    used to select a pod based on namespaces.
+                  type: string
+                order:
+                  description: Order is an optional field that specifies the order in
+                    which the policy is applied. Policies with higher "order" are applied
+                    after those with lower order.  If the order is omitted, it may be
+                    considered to be "infinite" - i.e. the policy will be applied last.  Policies
+                    with identical order will be applied in alphanumerical order based
+                    on the Policy "Name".
+                  type: number
+                preDNAT:
+                  description: PreDNAT indicates to apply the rules in this policy before
+                    any DNAT.
+                  type: boolean
+                selector:
+                  description: "The selector is an expression used to pick pick out
+                  the endpoints that the policy should be applied to. \n Selector
+                  expressions follow this syntax: \n \tlabel == \"string_literal\"
+                  \ ->  comparison, e.g. my_label == \"foo bar\" \tlabel != \"string_literal\"
+                  \  ->  not equal; also matches if label is not present \tlabel in
+                  { \"a\", \"b\", \"c\", ... }  ->  true if the value of label X is
+                  one of \"a\", \"b\", \"c\" \tlabel not in { \"a\", \"b\", \"c\",
+                  ... }  ->  true if the value of label X is not one of \"a\", \"b\",
+                  \"c\" \thas(label_name)  -> True if that label is present \t! expr
+                  -> negation of expr \texpr && expr  -> Short-circuit and \texpr
+                  || expr  -> Short-circuit or \t( expr ) -> parens for grouping \tall()
+                  or the empty selector -> matches all endpoints. \n Label names are
+                  allowed to contain alphanumerics, -, _ and /. String literals are
+                  more permissive but they do not support escape characters. \n Examples
+                  (with made-up labels): \n \ttype == \"webserver\" && deployment
+                  == \"prod\" \ttype in {\"frontend\", \"backend\"} \tdeployment !=
+                  \"dev\" \t! has(label_name)"
+                  type: string
+                serviceAccountSelector:
+                  description: ServiceAccountSelector is an optional field for an expression
+                    used to select a pod based on service accounts.
+                  type: string
+                types:
+                  description: "Types indicates whether this policy applies to ingress,
+                  or to egress, or to both.  When not explicitly specified (and so
+                  the value on creation is empty or nil), Calico defaults Types according
+                  to what Ingress and Egress rules are present in the policy.  The
+                  default is: \n - [ PolicyTypeIngress ], if there are no Egress rules
+                  (including the case where there are   also no Ingress rules) \n
+                  - [ PolicyTypeEgress ], if there are Egress rules but no Ingress
+                  rules \n - [ PolicyTypeIngress, PolicyTypeEgress ], if there are
+                  both Ingress and Egress rules. \n When the policy is read back again,
+                  Types will always be one of these values, never empty or nil."
+                  items:
+                    description: PolicyType enumerates the possible values of the PolicySpec
+                      Types field.
+                    type: string
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/yamls/crd/crd.projectcalico.org_globalnetworksets.yaml
+++ b/yamls/crd/crd.projectcalico.org_globalnetworksets.yaml
@@ -1,0 +1,53 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: globalnetworksets.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: GlobalNetworkSet
+    listKind: GlobalNetworkSetList
+    plural: globalnetworksets
+    singular: globalnetworkset
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: GlobalNetworkSet contains a set of arbitrary IP sub-networks/CIDRs
+            that share labels to allow rules to refer to them via selectors.  The labels
+            of GlobalNetworkSet are not namespaced.
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: GlobalNetworkSetSpec contains the specification for a NetworkSet
+                resource.
+              properties:
+                nets:
+                  description: The list of IP networks that belong to this set.
+                  items:
+                    type: string
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/yamls/crd/crd.projectcalico.org_hostendpoints.yaml
+++ b/yamls/crd/crd.projectcalico.org_hostendpoints.yaml
@@ -1,0 +1,108 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: hostendpoints.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: HostEndpoint
+    listKind: HostEndpointList
+    plural: hostendpoints
+    singular: hostendpoint
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: HostEndpointSpec contains the specification for a HostEndpoint
+                resource.
+              properties:
+                expectedIPs:
+                  description: "The expected IP addresses (IPv4 and IPv6) of the endpoint.
+                  If \"InterfaceName\" is not present, Calico will look for an interface
+                  matching any of the IPs in the list and apply policy to that. Note:
+                  \tWhen using the selector match criteria in an ingress or egress
+                  security Policy \tor Profile, Calico converts the selector into
+                  a set of IP addresses. For host \tendpoints, the ExpectedIPs field
+                  is used for that purpose. (If only the interface \tname is specified,
+                  Calico does not learn the IPs of the interface for use in match
+                  \tcriteria.)"
+                  items:
+                    type: string
+                  type: array
+                interfaceName:
+                  description: "Either \"*\", or the name of a specific Linux interface
+                  to apply policy to; or empty.  \"*\" indicates that this HostEndpoint
+                  governs all traffic to, from or through the default network namespace
+                  of the host named by the \"Node\" field; entering and leaving that
+                  namespace via any interface, including those from/to non-host-networked
+                  local workloads. \n If InterfaceName is not \"*\", this HostEndpoint
+                  only governs traffic that enters or leaves the host through the
+                  specific interface named by InterfaceName, or - when InterfaceName
+                  is empty - through the specific interface that has one of the IPs
+                  in ExpectedIPs. Therefore, when InterfaceName is empty, at least
+                  one expected IP must be specified.  Only external interfaces (such
+                  as \"eth0\") are supported here; it isn't possible for a HostEndpoint
+                  to protect traffic through a specific local workload interface.
+                  \n Note: Only some kinds of policy are implemented for \"*\" HostEndpoints;
+                  initially just pre-DNAT policy.  Please check Calico documentation
+                  for the latest position."
+                  type: string
+                node:
+                  description: The node name identifying the Calico node instance.
+                  type: string
+                ports:
+                  description: Ports contains the endpoint's named ports, which may
+                    be referenced in security policy rules.
+                  items:
+                    properties:
+                      name:
+                        type: string
+                      port:
+                        type: integer
+                      protocol:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^.*
+                        x-kubernetes-int-or-string: true
+                    required:
+                      - name
+                      - port
+                      - protocol
+                    type: object
+                  type: array
+                profiles:
+                  description: A list of identifiers of security Profile objects that
+                    apply to this endpoint. Each profile is applied in the order that
+                    they appear in this list.  Profile rules are applied after the selector-based
+                    security policy.
+                  items:
+                    type: string
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/yamls/crd/crd.projectcalico.org_ippools.yaml
+++ b/yamls/crd/crd.projectcalico.org_ippools.yaml
@@ -1,0 +1,99 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: ippools.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: IPPool
+    listKind: IPPoolList
+    plural: ippools
+    singular: ippool
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: IPPoolSpec contains the specification for an IPPool resource.
+              properties:
+                blockSize:
+                  description: The block size to use for IP address assignments from
+                    this pool. Defaults to 26 for IPv4 and 112 for IPv6.
+                  type: integer
+                cidr:
+                  description: The pool CIDR.
+                  type: string
+                disabled:
+                  description: When disabled is true, Calico IPAM will not assign addresses
+                    from this pool.
+                  type: boolean
+                ipip:
+                  description: 'Deprecated: this field is only used for APIv1 backwards
+                  compatibility. Setting this field is not allowed, this field is
+                  for internal use only.'
+                  properties:
+                    enabled:
+                      description: When enabled is true, ipip tunneling will be used
+                        to deliver packets to destinations within this pool.
+                      type: boolean
+                    mode:
+                      description: The IPIP mode.  This can be one of "always" or "cross-subnet".  A
+                        mode of "always" will also use IPIP tunneling for routing to
+                        destination IP addresses within this pool.  A mode of "cross-subnet"
+                        will only use IPIP tunneling when the destination node is on
+                        a different subnet to the originating node.  The default value
+                        (if not specified) is "always".
+                      type: string
+                  type: object
+                ipipMode:
+                  description: Contains configuration for IPIP tunneling for this pool.
+                    If not specified, then this is defaulted to "Never" (i.e. IPIP tunneling
+                    is disabled).
+                  type: string
+                nat-outgoing:
+                  description: 'Deprecated: this field is only used for APIv1 backwards
+                  compatibility. Setting this field is not allowed, this field is
+                  for internal use only.'
+                  type: boolean
+                natOutgoing:
+                  description: When nat-outgoing is true, packets sent from Calico networked
+                    containers in this pool to destinations outside of this pool will
+                    be masqueraded.
+                  type: boolean
+                nodeSelector:
+                  description: Allows IPPool to allocate for a specific node by label
+                    selector.
+                  type: string
+                vxlanMode:
+                  description: Contains configuration for VXLAN tunneling for this pool.
+                    If not specified, then this is defaulted to "Never" (i.e. VXLAN
+                    tunneling is disabled).
+                  type: string
+              required:
+                - cidr
+              type: object
+          type: object
+      served: true
+      storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/yamls/crd/crd.projectcalico.org_networkpolicies.yaml
+++ b/yamls/crd/crd.projectcalico.org_networkpolicies.yaml
@@ -1,0 +1,836 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: networkpolicies.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: NetworkPolicy
+    listKind: NetworkPolicyList
+    plural: networkpolicies
+    singular: networkpolicy
+  scope: Namespaced
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                egress:
+                  description: The ordered set of egress rules.  Each rule contains
+                    a set of packet match criteria and a corresponding action to apply.
+                  items:
+                    description: "A Rule encapsulates a set of match criteria and an
+                    action.  Both selector-based security Policy and security Profiles
+                    reference rules - separated out as a list of rules for both ingress
+                    and egress packet matching. \n Each positive match criteria has
+                    a negated version, prefixed with \"Not\". All the match criteria
+                    within a rule must be satisfied for a packet to match. A single
+                    rule can contain the positive and negative version of a match
+                    and both must be satisfied for the rule to match."
+                    properties:
+                      action:
+                        type: string
+                      destination:
+                        description: Destination contains the match criteria that apply
+                          to destination entity.
+                        properties:
+                          namespaceSelector:
+                            description: "NamespaceSelector is an optional field that
+                            contains a selector expression. Only traffic that originates
+                            from (or terminates at) endpoints within the selected
+                            namespaces will be matched. When both NamespaceSelector
+                            and another selector are defined on the same rule, then
+                            only workload endpoints that are matched by both selectors
+                            will be selected by the rule. \n For NetworkPolicy, an
+                            empty NamespaceSelector implies that the Selector is limited
+                            to selecting only workload endpoints in the same namespace
+                            as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                            NamespaceSelector implies that the Selector is limited
+                            to selecting only GlobalNetworkSet or HostEndpoint. \n
+                            For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                            the Selector applies to workload endpoints across all
+                            namespaces."
+                            type: string
+                          nets:
+                            description: Nets is an optional field that restricts the
+                              rule to only apply to traffic that originates from (or
+                              terminates at) IP addresses in any of the given subnets.
+                            items:
+                              type: string
+                            type: array
+                          notNets:
+                            description: NotNets is the negated version of the Nets
+                              field.
+                            items:
+                              type: string
+                            type: array
+                          notPorts:
+                            description: NotPorts is the negated version of the Ports
+                              field. Since only some protocols have ports, if any ports
+                              are specified it requires the Protocol match in the Rule
+                              to be set to "TCP" or "UDP".
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          notSelector:
+                            description: NotSelector is the negated version of the Selector
+                              field.  See Selector field for subtleties with negated
+                              selectors.
+                            type: string
+                          ports:
+                            description: "Ports is an optional field that restricts
+                            the rule to only apply to traffic that has a source (destination)
+                            port that matches one of these ranges/values. This value
+                            is a list of integers or strings that represent ranges
+                            of ports. \n Since only some protocols have ports, if
+                            any ports are specified it requires the Protocol match
+                            in the Rule to be set to \"TCP\" or \"UDP\"."
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          selector:
+                            description: "Selector is an optional field that contains
+                            a selector expression (see Policy for sample syntax).
+                            \ Only traffic that originates from (terminates at) endpoints
+                            matching the selector will be matched. \n Note that: in
+                            addition to the negated version of the Selector (see NotSelector
+                            below), the selector expression syntax itself supports
+                            negation.  The two types of negation are subtly different.
+                            One negates the set of matched endpoints, the other negates
+                            the whole match: \n \tSelector = \"!has(my_label)\" matches
+                            packets that are from other Calico-controlled \tendpoints
+                            that do not have the label \"my_label\". \n \tNotSelector
+                            = \"has(my_label)\" matches packets that are not from
+                            Calico-controlled \tendpoints that do have the label \"my_label\".
+                            \n The effect is that the latter will accept packets from
+                            non-Calico sources whereas the former is limited to packets
+                            from Calico-controlled endpoints."
+                            type: string
+                          serviceAccounts:
+                            description: ServiceAccounts is an optional field that restricts
+                              the rule to only apply to traffic that originates from
+                              (or terminates at) a pod running as a matching service
+                              account.
+                            properties:
+                              names:
+                                description: Names is an optional field that restricts
+                                  the rule to only apply to traffic that originates
+                                  from (or terminates at) a pod running as a service
+                                  account whose name is in the list.
+                                items:
+                                  type: string
+                                type: array
+                              selector:
+                                description: Selector is an optional field that restricts
+                                  the rule to only apply to traffic that originates
+                                  from (or terminates at) a pod running as a service
+                                  account that matches the given label selector. If
+                                  both Names and Selector are specified then they are
+                                  AND'ed.
+                                type: string
+                            type: object
+                          services:
+                            description: "Services is an optional field that contains
+                            options for matching Kubernetes Services. If specified,
+                            only traffic that originates from or terminates at endpoints
+                            within the selected service(s) will be matched, and only
+                            to/from each endpoint's port. \n Services cannot be specified
+                            on the same rule as Selector, NotSelector, NamespaceSelector,
+                            Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                            Only valid on egress rules."
+                            properties:
+                              name:
+                                description: Name specifies the name of a Kubernetes
+                                  Service to match.
+                                type: string
+                              namespace:
+                                description: Namespace specifies the namespace of the
+                                  given Service. If left empty, the rule will match
+                                  within this policy's namespace.
+                                type: string
+                            type: object
+                        type: object
+                      http:
+                        description: HTTP contains match criteria that apply to HTTP
+                          requests.
+                        properties:
+                          methods:
+                            description: Methods is an optional field that restricts
+                              the rule to apply only to HTTP requests that use one of
+                              the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
+                              methods are OR'd together.
+                            items:
+                              type: string
+                            type: array
+                          paths:
+                            description: 'Paths is an optional field that restricts
+                            the rule to apply to HTTP requests that use one of the
+                            listed HTTP Paths. Multiple paths are OR''d together.
+                            e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
+                            ONLY specify either a `exact` or a `prefix` match. The
+                            validator will check for it.'
+                            items:
+                              description: 'HTTPPath specifies an HTTP path to match.
+                              It may be either of the form: exact: <path>: which matches
+                              the path exactly or prefix: <path-prefix>: which matches
+                              the path prefix'
+                              properties:
+                                exact:
+                                  type: string
+                                prefix:
+                                  type: string
+                              type: object
+                            type: array
+                        type: object
+                      icmp:
+                        description: ICMP is an optional field that restricts the rule
+                          to apply to a specific type and code of ICMP traffic.  This
+                          should only be specified if the Protocol field is set to "ICMP"
+                          or "ICMPv6".
+                        properties:
+                          code:
+                            description: Match on a specific ICMP code.  If specified,
+                              the Type value must also be specified. This is a technical
+                              limitation imposed by the kernel's iptables firewall,
+                              which Calico uses to enforce the rule.
+                            type: integer
+                          type:
+                            description: Match on a specific ICMP type.  For example
+                              a value of 8 refers to ICMP Echo Request (i.e. pings).
+                            type: integer
+                        type: object
+                      ipVersion:
+                        description: IPVersion is an optional field that restricts the
+                          rule to only match a specific IP version.
+                        type: integer
+                      metadata:
+                        description: Metadata contains additional information for this
+                          rule
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            description: Annotations is a set of key value pairs that
+                              give extra information about the rule
+                            type: object
+                        type: object
+                      notICMP:
+                        description: NotICMP is the negated version of the ICMP field.
+                        properties:
+                          code:
+                            description: Match on a specific ICMP code.  If specified,
+                              the Type value must also be specified. This is a technical
+                              limitation imposed by the kernel's iptables firewall,
+                              which Calico uses to enforce the rule.
+                            type: integer
+                          type:
+                            description: Match on a specific ICMP type.  For example
+                              a value of 8 refers to ICMP Echo Request (i.e. pings).
+                            type: integer
+                        type: object
+                      notProtocol:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        description: NotProtocol is the negated version of the Protocol
+                          field.
+                        pattern: ^.*
+                        x-kubernetes-int-or-string: true
+                      protocol:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        description: "Protocol is an optional field that restricts the
+                        rule to only apply to traffic of a specific IP protocol. Required
+                        if any of the EntityRules contain Ports (because ports only
+                        apply to certain protocols). \n Must be one of these string
+                        values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
+                        \"UDPLite\" or an integer in the range 1-255."
+                        pattern: ^.*
+                        x-kubernetes-int-or-string: true
+                      source:
+                        description: Source contains the match criteria that apply to
+                          source entity.
+                        properties:
+                          namespaceSelector:
+                            description: "NamespaceSelector is an optional field that
+                            contains a selector expression. Only traffic that originates
+                            from (or terminates at) endpoints within the selected
+                            namespaces will be matched. When both NamespaceSelector
+                            and another selector are defined on the same rule, then
+                            only workload endpoints that are matched by both selectors
+                            will be selected by the rule. \n For NetworkPolicy, an
+                            empty NamespaceSelector implies that the Selector is limited
+                            to selecting only workload endpoints in the same namespace
+                            as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                            NamespaceSelector implies that the Selector is limited
+                            to selecting only GlobalNetworkSet or HostEndpoint. \n
+                            For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                            the Selector applies to workload endpoints across all
+                            namespaces."
+                            type: string
+                          nets:
+                            description: Nets is an optional field that restricts the
+                              rule to only apply to traffic that originates from (or
+                              terminates at) IP addresses in any of the given subnets.
+                            items:
+                              type: string
+                            type: array
+                          notNets:
+                            description: NotNets is the negated version of the Nets
+                              field.
+                            items:
+                              type: string
+                            type: array
+                          notPorts:
+                            description: NotPorts is the negated version of the Ports
+                              field. Since only some protocols have ports, if any ports
+                              are specified it requires the Protocol match in the Rule
+                              to be set to "TCP" or "UDP".
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          notSelector:
+                            description: NotSelector is the negated version of the Selector
+                              field.  See Selector field for subtleties with negated
+                              selectors.
+                            type: string
+                          ports:
+                            description: "Ports is an optional field that restricts
+                            the rule to only apply to traffic that has a source (destination)
+                            port that matches one of these ranges/values. This value
+                            is a list of integers or strings that represent ranges
+                            of ports. \n Since only some protocols have ports, if
+                            any ports are specified it requires the Protocol match
+                            in the Rule to be set to \"TCP\" or \"UDP\"."
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          selector:
+                            description: "Selector is an optional field that contains
+                            a selector expression (see Policy for sample syntax).
+                            \ Only traffic that originates from (terminates at) endpoints
+                            matching the selector will be matched. \n Note that: in
+                            addition to the negated version of the Selector (see NotSelector
+                            below), the selector expression syntax itself supports
+                            negation.  The two types of negation are subtly different.
+                            One negates the set of matched endpoints, the other negates
+                            the whole match: \n \tSelector = \"!has(my_label)\" matches
+                            packets that are from other Calico-controlled \tendpoints
+                            that do not have the label \"my_label\". \n \tNotSelector
+                            = \"has(my_label)\" matches packets that are not from
+                            Calico-controlled \tendpoints that do have the label \"my_label\".
+                            \n The effect is that the latter will accept packets from
+                            non-Calico sources whereas the former is limited to packets
+                            from Calico-controlled endpoints."
+                            type: string
+                          serviceAccounts:
+                            description: ServiceAccounts is an optional field that restricts
+                              the rule to only apply to traffic that originates from
+                              (or terminates at) a pod running as a matching service
+                              account.
+                            properties:
+                              names:
+                                description: Names is an optional field that restricts
+                                  the rule to only apply to traffic that originates
+                                  from (or terminates at) a pod running as a service
+                                  account whose name is in the list.
+                                items:
+                                  type: string
+                                type: array
+                              selector:
+                                description: Selector is an optional field that restricts
+                                  the rule to only apply to traffic that originates
+                                  from (or terminates at) a pod running as a service
+                                  account that matches the given label selector. If
+                                  both Names and Selector are specified then they are
+                                  AND'ed.
+                                type: string
+                            type: object
+                          services:
+                            description: "Services is an optional field that contains
+                            options for matching Kubernetes Services. If specified,
+                            only traffic that originates from or terminates at endpoints
+                            within the selected service(s) will be matched, and only
+                            to/from each endpoint's port. \n Services cannot be specified
+                            on the same rule as Selector, NotSelector, NamespaceSelector,
+                            Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                            Only valid on egress rules."
+                            properties:
+                              name:
+                                description: Name specifies the name of a Kubernetes
+                                  Service to match.
+                                type: string
+                              namespace:
+                                description: Namespace specifies the namespace of the
+                                  given Service. If left empty, the rule will match
+                                  within this policy's namespace.
+                                type: string
+                            type: object
+                        type: object
+                    required:
+                      - action
+                    type: object
+                  type: array
+                ingress:
+                  description: The ordered set of ingress rules.  Each rule contains
+                    a set of packet match criteria and a corresponding action to apply.
+                  items:
+                    description: "A Rule encapsulates a set of match criteria and an
+                    action.  Both selector-based security Policy and security Profiles
+                    reference rules - separated out as a list of rules for both ingress
+                    and egress packet matching. \n Each positive match criteria has
+                    a negated version, prefixed with \"Not\". All the match criteria
+                    within a rule must be satisfied for a packet to match. A single
+                    rule can contain the positive and negative version of a match
+                    and both must be satisfied for the rule to match."
+                    properties:
+                      action:
+                        type: string
+                      destination:
+                        description: Destination contains the match criteria that apply
+                          to destination entity.
+                        properties:
+                          namespaceSelector:
+                            description: "NamespaceSelector is an optional field that
+                            contains a selector expression. Only traffic that originates
+                            from (or terminates at) endpoints within the selected
+                            namespaces will be matched. When both NamespaceSelector
+                            and another selector are defined on the same rule, then
+                            only workload endpoints that are matched by both selectors
+                            will be selected by the rule. \n For NetworkPolicy, an
+                            empty NamespaceSelector implies that the Selector is limited
+                            to selecting only workload endpoints in the same namespace
+                            as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                            NamespaceSelector implies that the Selector is limited
+                            to selecting only GlobalNetworkSet or HostEndpoint. \n
+                            For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                            the Selector applies to workload endpoints across all
+                            namespaces."
+                            type: string
+                          nets:
+                            description: Nets is an optional field that restricts the
+                              rule to only apply to traffic that originates from (or
+                              terminates at) IP addresses in any of the given subnets.
+                            items:
+                              type: string
+                            type: array
+                          notNets:
+                            description: NotNets is the negated version of the Nets
+                              field.
+                            items:
+                              type: string
+                            type: array
+                          notPorts:
+                            description: NotPorts is the negated version of the Ports
+                              field. Since only some protocols have ports, if any ports
+                              are specified it requires the Protocol match in the Rule
+                              to be set to "TCP" or "UDP".
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          notSelector:
+                            description: NotSelector is the negated version of the Selector
+                              field.  See Selector field for subtleties with negated
+                              selectors.
+                            type: string
+                          ports:
+                            description: "Ports is an optional field that restricts
+                            the rule to only apply to traffic that has a source (destination)
+                            port that matches one of these ranges/values. This value
+                            is a list of integers or strings that represent ranges
+                            of ports. \n Since only some protocols have ports, if
+                            any ports are specified it requires the Protocol match
+                            in the Rule to be set to \"TCP\" or \"UDP\"."
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          selector:
+                            description: "Selector is an optional field that contains
+                            a selector expression (see Policy for sample syntax).
+                            \ Only traffic that originates from (terminates at) endpoints
+                            matching the selector will be matched. \n Note that: in
+                            addition to the negated version of the Selector (see NotSelector
+                            below), the selector expression syntax itself supports
+                            negation.  The two types of negation are subtly different.
+                            One negates the set of matched endpoints, the other negates
+                            the whole match: \n \tSelector = \"!has(my_label)\" matches
+                            packets that are from other Calico-controlled \tendpoints
+                            that do not have the label \"my_label\". \n \tNotSelector
+                            = \"has(my_label)\" matches packets that are not from
+                            Calico-controlled \tendpoints that do have the label \"my_label\".
+                            \n The effect is that the latter will accept packets from
+                            non-Calico sources whereas the former is limited to packets
+                            from Calico-controlled endpoints."
+                            type: string
+                          serviceAccounts:
+                            description: ServiceAccounts is an optional field that restricts
+                              the rule to only apply to traffic that originates from
+                              (or terminates at) a pod running as a matching service
+                              account.
+                            properties:
+                              names:
+                                description: Names is an optional field that restricts
+                                  the rule to only apply to traffic that originates
+                                  from (or terminates at) a pod running as a service
+                                  account whose name is in the list.
+                                items:
+                                  type: string
+                                type: array
+                              selector:
+                                description: Selector is an optional field that restricts
+                                  the rule to only apply to traffic that originates
+                                  from (or terminates at) a pod running as a service
+                                  account that matches the given label selector. If
+                                  both Names and Selector are specified then they are
+                                  AND'ed.
+                                type: string
+                            type: object
+                          services:
+                            description: "Services is an optional field that contains
+                            options for matching Kubernetes Services. If specified,
+                            only traffic that originates from or terminates at endpoints
+                            within the selected service(s) will be matched, and only
+                            to/from each endpoint's port. \n Services cannot be specified
+                            on the same rule as Selector, NotSelector, NamespaceSelector,
+                            Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                            Only valid on egress rules."
+                            properties:
+                              name:
+                                description: Name specifies the name of a Kubernetes
+                                  Service to match.
+                                type: string
+                              namespace:
+                                description: Namespace specifies the namespace of the
+                                  given Service. If left empty, the rule will match
+                                  within this policy's namespace.
+                                type: string
+                            type: object
+                        type: object
+                      http:
+                        description: HTTP contains match criteria that apply to HTTP
+                          requests.
+                        properties:
+                          methods:
+                            description: Methods is an optional field that restricts
+                              the rule to apply only to HTTP requests that use one of
+                              the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
+                              methods are OR'd together.
+                            items:
+                              type: string
+                            type: array
+                          paths:
+                            description: 'Paths is an optional field that restricts
+                            the rule to apply to HTTP requests that use one of the
+                            listed HTTP Paths. Multiple paths are OR''d together.
+                            e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
+                            ONLY specify either a `exact` or a `prefix` match. The
+                            validator will check for it.'
+                            items:
+                              description: 'HTTPPath specifies an HTTP path to match.
+                              It may be either of the form: exact: <path>: which matches
+                              the path exactly or prefix: <path-prefix>: which matches
+                              the path prefix'
+                              properties:
+                                exact:
+                                  type: string
+                                prefix:
+                                  type: string
+                              type: object
+                            type: array
+                        type: object
+                      icmp:
+                        description: ICMP is an optional field that restricts the rule
+                          to apply to a specific type and code of ICMP traffic.  This
+                          should only be specified if the Protocol field is set to "ICMP"
+                          or "ICMPv6".
+                        properties:
+                          code:
+                            description: Match on a specific ICMP code.  If specified,
+                              the Type value must also be specified. This is a technical
+                              limitation imposed by the kernel's iptables firewall,
+                              which Calico uses to enforce the rule.
+                            type: integer
+                          type:
+                            description: Match on a specific ICMP type.  For example
+                              a value of 8 refers to ICMP Echo Request (i.e. pings).
+                            type: integer
+                        type: object
+                      ipVersion:
+                        description: IPVersion is an optional field that restricts the
+                          rule to only match a specific IP version.
+                        type: integer
+                      metadata:
+                        description: Metadata contains additional information for this
+                          rule
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            description: Annotations is a set of key value pairs that
+                              give extra information about the rule
+                            type: object
+                        type: object
+                      notICMP:
+                        description: NotICMP is the negated version of the ICMP field.
+                        properties:
+                          code:
+                            description: Match on a specific ICMP code.  If specified,
+                              the Type value must also be specified. This is a technical
+                              limitation imposed by the kernel's iptables firewall,
+                              which Calico uses to enforce the rule.
+                            type: integer
+                          type:
+                            description: Match on a specific ICMP type.  For example
+                              a value of 8 refers to ICMP Echo Request (i.e. pings).
+                            type: integer
+                        type: object
+                      notProtocol:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        description: NotProtocol is the negated version of the Protocol
+                          field.
+                        pattern: ^.*
+                        x-kubernetes-int-or-string: true
+                      protocol:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        description: "Protocol is an optional field that restricts the
+                        rule to only apply to traffic of a specific IP protocol. Required
+                        if any of the EntityRules contain Ports (because ports only
+                        apply to certain protocols). \n Must be one of these string
+                        values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
+                        \"UDPLite\" or an integer in the range 1-255."
+                        pattern: ^.*
+                        x-kubernetes-int-or-string: true
+                      source:
+                        description: Source contains the match criteria that apply to
+                          source entity.
+                        properties:
+                          namespaceSelector:
+                            description: "NamespaceSelector is an optional field that
+                            contains a selector expression. Only traffic that originates
+                            from (or terminates at) endpoints within the selected
+                            namespaces will be matched. When both NamespaceSelector
+                            and another selector are defined on the same rule, then
+                            only workload endpoints that are matched by both selectors
+                            will be selected by the rule. \n For NetworkPolicy, an
+                            empty NamespaceSelector implies that the Selector is limited
+                            to selecting only workload endpoints in the same namespace
+                            as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                            NamespaceSelector implies that the Selector is limited
+                            to selecting only GlobalNetworkSet or HostEndpoint. \n
+                            For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                            the Selector applies to workload endpoints across all
+                            namespaces."
+                            type: string
+                          nets:
+                            description: Nets is an optional field that restricts the
+                              rule to only apply to traffic that originates from (or
+                              terminates at) IP addresses in any of the given subnets.
+                            items:
+                              type: string
+                            type: array
+                          notNets:
+                            description: NotNets is the negated version of the Nets
+                              field.
+                            items:
+                              type: string
+                            type: array
+                          notPorts:
+                            description: NotPorts is the negated version of the Ports
+                              field. Since only some protocols have ports, if any ports
+                              are specified it requires the Protocol match in the Rule
+                              to be set to "TCP" or "UDP".
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          notSelector:
+                            description: NotSelector is the negated version of the Selector
+                              field.  See Selector field for subtleties with negated
+                              selectors.
+                            type: string
+                          ports:
+                            description: "Ports is an optional field that restricts
+                            the rule to only apply to traffic that has a source (destination)
+                            port that matches one of these ranges/values. This value
+                            is a list of integers or strings that represent ranges
+                            of ports. \n Since only some protocols have ports, if
+                            any ports are specified it requires the Protocol match
+                            in the Rule to be set to \"TCP\" or \"UDP\"."
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          selector:
+                            description: "Selector is an optional field that contains
+                            a selector expression (see Policy for sample syntax).
+                            \ Only traffic that originates from (terminates at) endpoints
+                            matching the selector will be matched. \n Note that: in
+                            addition to the negated version of the Selector (see NotSelector
+                            below), the selector expression syntax itself supports
+                            negation.  The two types of negation are subtly different.
+                            One negates the set of matched endpoints, the other negates
+                            the whole match: \n \tSelector = \"!has(my_label)\" matches
+                            packets that are from other Calico-controlled \tendpoints
+                            that do not have the label \"my_label\". \n \tNotSelector
+                            = \"has(my_label)\" matches packets that are not from
+                            Calico-controlled \tendpoints that do have the label \"my_label\".
+                            \n The effect is that the latter will accept packets from
+                            non-Calico sources whereas the former is limited to packets
+                            from Calico-controlled endpoints."
+                            type: string
+                          serviceAccounts:
+                            description: ServiceAccounts is an optional field that restricts
+                              the rule to only apply to traffic that originates from
+                              (or terminates at) a pod running as a matching service
+                              account.
+                            properties:
+                              names:
+                                description: Names is an optional field that restricts
+                                  the rule to only apply to traffic that originates
+                                  from (or terminates at) a pod running as a service
+                                  account whose name is in the list.
+                                items:
+                                  type: string
+                                type: array
+                              selector:
+                                description: Selector is an optional field that restricts
+                                  the rule to only apply to traffic that originates
+                                  from (or terminates at) a pod running as a service
+                                  account that matches the given label selector. If
+                                  both Names and Selector are specified then they are
+                                  AND'ed.
+                                type: string
+                            type: object
+                          services:
+                            description: "Services is an optional field that contains
+                            options for matching Kubernetes Services. If specified,
+                            only traffic that originates from or terminates at endpoints
+                            within the selected service(s) will be matched, and only
+                            to/from each endpoint's port. \n Services cannot be specified
+                            on the same rule as Selector, NotSelector, NamespaceSelector,
+                            Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                            Only valid on egress rules."
+                            properties:
+                              name:
+                                description: Name specifies the name of a Kubernetes
+                                  Service to match.
+                                type: string
+                              namespace:
+                                description: Namespace specifies the namespace of the
+                                  given Service. If left empty, the rule will match
+                                  within this policy's namespace.
+                                type: string
+                            type: object
+                        type: object
+                    required:
+                      - action
+                    type: object
+                  type: array
+                order:
+                  description: Order is an optional field that specifies the order in
+                    which the policy is applied. Policies with higher "order" are applied
+                    after those with lower order.  If the order is omitted, it may be
+                    considered to be "infinite" - i.e. the policy will be applied last.  Policies
+                    with identical order will be applied in alphanumerical order based
+                    on the Policy "Name".
+                  type: number
+                selector:
+                  description: "The selector is an expression used to pick pick out
+                  the endpoints that the policy should be applied to. \n Selector
+                  expressions follow this syntax: \n \tlabel == \"string_literal\"
+                  \ ->  comparison, e.g. my_label == \"foo bar\" \tlabel != \"string_literal\"
+                  \  ->  not equal; also matches if label is not present \tlabel in
+                  { \"a\", \"b\", \"c\", ... }  ->  true if the value of label X is
+                  one of \"a\", \"b\", \"c\" \tlabel not in { \"a\", \"b\", \"c\",
+                  ... }  ->  true if the value of label X is not one of \"a\", \"b\",
+                  \"c\" \thas(label_name)  -> True if that label is present \t! expr
+                  -> negation of expr \texpr && expr  -> Short-circuit and \texpr
+                  || expr  -> Short-circuit or \t( expr ) -> parens for grouping \tall()
+                  or the empty selector -> matches all endpoints. \n Label names are
+                  allowed to contain alphanumerics, -, _ and /. String literals are
+                  more permissive but they do not support escape characters. \n Examples
+                  (with made-up labels): \n \ttype == \"webserver\" && deployment
+                  == \"prod\" \ttype in {\"frontend\", \"backend\"} \tdeployment !=
+                  \"dev\" \t! has(label_name)"
+                  type: string
+                serviceAccountSelector:
+                  description: ServiceAccountSelector is an optional field for an expression
+                    used to select a pod based on service accounts.
+                  type: string
+                types:
+                  description: "Types indicates whether this policy applies to ingress,
+                  or to egress, or to both.  When not explicitly specified (and so
+                  the value on creation is empty or nil), Calico defaults Types according
+                  to what Ingress and Egress are present in the policy.  The default
+                  is: \n - [ PolicyTypeIngress ], if there are no Egress rules (including
+                  the case where there are   also no Ingress rules) \n - [ PolicyTypeEgress
+                  ], if there are Egress rules but no Ingress rules \n - [ PolicyTypeIngress,
+                  PolicyTypeEgress ], if there are both Ingress and Egress rules.
+                  \n When the policy is read back again, Types will always be one
+                  of these values, never empty or nil."
+                  items:
+                    description: PolicyType enumerates the possible values of the PolicySpec
+                      Types field.
+                    type: string
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/yamls/hybridnet-components.yaml
+++ b/yamls/hybridnet-components.yaml
@@ -87,6 +87,20 @@ spec:
               mountPropagation: HostToContainer
               name: host-docker-netns
           # TODO: add liveness probe
+        - name: policy
+          image: "hybridnetdev/hybridnet:latest"
+          imagePullPolicy: IfNotPresent
+          command:
+            - /hybridnet/policyinit.sh
+          env:
+            - name: NODENAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+          securityContext:
+            privileged: true
+            runAsUser: 0
       nodeSelector:
         kubernetes.io/os: "linux"
       volumes:

--- a/yamls/hybridnet-components.yaml
+++ b/yamls/hybridnet-components.yaml
@@ -98,6 +98,9 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
+          resources:
+            requests:
+              cpu: 250m
           securityContext:
             privileged: true
             runAsUser: 0

--- a/yamls/hybridnet-init.yaml
+++ b/yamls/hybridnet-init.yaml
@@ -40,6 +40,7 @@ rules:
       - configmaps
       - services
       - endpoints
+      - serviceaccounts
     verbs:
       - create
       - get
@@ -83,6 +84,20 @@ rules:
       - "*"
     verbs:
       - "*"
+  - apiGroups:
+      - "crd.projectcalico.org"
+    resources:
+      - "*"
+    verbs:
+      - "*"
+  - apiGroups:
+      - "discovery.k8s.io"
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+      - watch
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -97,6 +112,2727 @@ subjects:
   - kind: ServiceAccount
     name: hybridnet
     namespace: kube-system
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: bgpconfigurations.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: BGPConfiguration
+    listKind: BGPConfigurationList
+    plural: bgpconfigurations
+    singular: bgpconfiguration
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: BGPConfiguration contains the configuration for any BGP routing.
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: BGPConfigurationSpec contains the values of the BGP configuration.
+              properties:
+                asNumber:
+                  description: 'ASNumber is the default AS number used by a node. [Default:
+                  64512]'
+                  format: int32
+                  type: integer
+                communities:
+                  description: Communities is a list of BGP community values and their
+                    arbitrary names for tagging routes.
+                  items:
+                    description: Community contains standard or large community value
+                      and its name.
+                    properties:
+                      name:
+                        description: Name given to community value.
+                        type: string
+                      value:
+                        description: Value must be of format `aa:nn` or `aa:nn:mm`.
+                          For standard community use `aa:nn` format, where `aa` and
+                          `nn` are 16 bit number. For large community use `aa:nn:mm`
+                          format, where `aa`, `nn` and `mm` are 32 bit number. Where,
+                          `aa` is an AS Number, `nn` and `mm` are per-AS identifier.
+                        pattern: ^(\d+):(\d+)$|^(\d+):(\d+):(\d+)$
+                        type: string
+                    type: object
+                  type: array
+                listenPort:
+                  description: ListenPort is the port where BGP protocol should listen.
+                    Defaults to 179
+                  maximum: 65535
+                  minimum: 1
+                  type: integer
+                logSeverityScreen:
+                  description: 'LogSeverityScreen is the log severity above which logs
+                  are sent to the stdout. [Default: INFO]'
+                  type: string
+                nodeToNodeMeshEnabled:
+                  description: 'NodeToNodeMeshEnabled sets whether full node to node
+                  BGP mesh is enabled. [Default: true]'
+                  type: boolean
+                prefixAdvertisements:
+                  description: PrefixAdvertisements contains per-prefix advertisement
+                    configuration.
+                  items:
+                    description: PrefixAdvertisement configures advertisement properties
+                      for the specified CIDR.
+                    properties:
+                      cidr:
+                        description: CIDR for which properties should be advertised.
+                        type: string
+                      communities:
+                        description: Communities can be list of either community names
+                          already defined in `Specs.Communities` or community value
+                          of format `aa:nn` or `aa:nn:mm`. For standard community use
+                          `aa:nn` format, where `aa` and `nn` are 16 bit number. For
+                          large community use `aa:nn:mm` format, where `aa`, `nn` and
+                          `mm` are 32 bit number. Where,`aa` is an AS Number, `nn` and
+                          `mm` are per-AS identifier.
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  type: array
+                serviceClusterIPs:
+                  description: ServiceClusterIPs are the CIDR blocks from which service
+                    cluster IPs are allocated. If specified, Calico will advertise these
+                    blocks, as well as any cluster IPs within them.
+                  items:
+                    description: ServiceClusterIPBlock represents a single allowed ClusterIP
+                      CIDR block.
+                    properties:
+                      cidr:
+                        type: string
+                    type: object
+                  type: array
+                serviceExternalIPs:
+                  description: ServiceExternalIPs are the CIDR blocks for Kubernetes
+                    Service External IPs. Kubernetes Service ExternalIPs will only be
+                    advertised if they are within one of these blocks.
+                  items:
+                    description: ServiceExternalIPBlock represents a single allowed
+                      External IP CIDR block.
+                    properties:
+                      cidr:
+                        type: string
+                    type: object
+                  type: array
+                serviceLoadBalancerIPs:
+                  description: ServiceLoadBalancerIPs are the CIDR blocks for Kubernetes
+                    Service LoadBalancer IPs. Kubernetes Service status.LoadBalancer.Ingress
+                    IPs will only be advertised if they are within one of these blocks.
+                  items:
+                    description: ServiceLoadBalancerIPBlock represents a single allowed
+                      LoadBalancer IP CIDR block.
+                    properties:
+                      cidr:
+                        type: string
+                    type: object
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: clusterinformations.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: ClusterInformation
+    listKind: ClusterInformationList
+    plural: clusterinformations
+    singular: clusterinformation
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: ClusterInformation contains the cluster specific information.
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ClusterInformationSpec contains the values of describing
+                the cluster.
+              properties:
+                calicoVersion:
+                  description: CalicoVersion is the version of Calico that the cluster
+                    is running
+                  type: string
+                clusterGUID:
+                  description: ClusterGUID is the GUID of the cluster
+                  type: string
+                clusterType:
+                  description: ClusterType describes the type of the cluster
+                  type: string
+                datastoreReady:
+                  description: DatastoreReady is used during significant datastore migrations
+                    to signal to components such as Felix that it should wait before
+                    accessing the datastore.
+                  type: boolean
+                variant:
+                  description: Variant declares which variant of Calico should be active.
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: felixconfigurations.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: FelixConfiguration
+    listKind: FelixConfigurationList
+    plural: felixconfigurations
+    singular: felixconfiguration
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: Felix Configuration contains the configuration for Felix.
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: FelixConfigurationSpec contains the values of the Felix configuration.
+              properties:
+                allowIPIPPacketsFromWorkloads:
+                  description: 'AllowIPIPPacketsFromWorkloads controls whether Felix
+                  will add a rule to drop IPIP encapsulated traffic from workloads
+                  [Default: false]'
+                  type: boolean
+                allowVXLANPacketsFromWorkloads:
+                  description: 'AllowVXLANPacketsFromWorkloads controls whether Felix
+                  will add a rule to drop VXLAN encapsulated traffic from workloads
+                  [Default: false]'
+                  type: boolean
+                awsSrcDstCheck:
+                  description: 'Set source-destination-check on AWS EC2 instances. Accepted
+                  value must be one of "DoNothing", "Enabled" or "Disabled". [Default:
+                  DoNothing]'
+                  enum:
+                    - DoNothing
+                    - Enable
+                    - Disable
+                  type: string
+                bpfConnectTimeLoadBalancingEnabled:
+                  description: 'BPFConnectTimeLoadBalancingEnabled when in BPF mode,
+                  controls whether Felix installs the connection-time load balancer.  The
+                  connect-time load balancer is required for the host to be able to
+                  reach Kubernetes services and it improves the performance of pod-to-service
+                  connections.  The only reason to disable it is for debugging purposes.  [Default:
+                  true]'
+                  type: boolean
+                bpfDataIfacePattern:
+                  description: BPFDataIfacePattern is a regular expression that controls
+                    which interfaces Felix should attach BPF programs to in order to
+                    catch traffic to/from the network.  This needs to match the interfaces
+                    that Calico workload traffic flows over as well as any interfaces
+                    that handle incoming traffic to nodeports and services from outside
+                    the cluster.  It should not match the workload interfaces (usually
+                    named cali...).
+                  type: string
+                bpfDisableUnprivileged:
+                  description: 'BPFDisableUnprivileged, if enabled, Felix sets the kernel.unprivileged_bpf_disabled
+                  sysctl to disable unprivileged use of BPF.  This ensures that unprivileged
+                  users cannot access Calico''s BPF maps and cannot insert their own
+                  BPF programs to interfere with Calico''s. [Default: true]'
+                  type: boolean
+                bpfEnabled:
+                  description: 'BPFEnabled, if enabled Felix will use the BPF dataplane.
+                  [Default: false]'
+                  type: boolean
+                bpfExternalServiceMode:
+                  description: 'BPFExternalServiceMode in BPF mode, controls how connections
+                  from outside the cluster to services (node ports and cluster IPs)
+                  are forwarded to remote workloads.  If set to "Tunnel" then both
+                  request and response traffic is tunneled to the remote node.  If
+                  set to "DSR", the request traffic is tunneled but the response traffic
+                  is sent directly from the remote node.  In "DSR" mode, the remote
+                  node appears to use the IP of the ingress node; this requires a
+                  permissive L2 network.  [Default: Tunnel]'
+                  type: string
+                bpfExtToServiceConnmark:
+                  description: 'BPFExtToServiceConnmark in BPF mode, controls a
+                  32bit mark that is set on connections from an external client to
+                  a local service. This mark allows us to control how packets of
+                  that connection are routed within the host and how is routing
+                  intepreted by RPF check. [Default: 0]'
+                  type: integer
+
+                bpfKubeProxyEndpointSlicesEnabled:
+                  description: BPFKubeProxyEndpointSlicesEnabled in BPF mode, controls
+                    whether Felix's embedded kube-proxy accepts EndpointSlices or not.
+                  type: boolean
+                bpfKubeProxyIptablesCleanupEnabled:
+                  description: 'BPFKubeProxyIptablesCleanupEnabled, if enabled in BPF
+                  mode, Felix will proactively clean up the upstream Kubernetes kube-proxy''s
+                  iptables chains.  Should only be enabled if kube-proxy is not running.  [Default:
+                  true]'
+                  type: boolean
+                bpfKubeProxyMinSyncPeriod:
+                  description: 'BPFKubeProxyMinSyncPeriod, in BPF mode, controls the
+                  minimum time between updates to the dataplane for Felix''s embedded
+                  kube-proxy.  Lower values give reduced set-up latency.  Higher values
+                  reduce Felix CPU usage by batching up more work.  [Default: 1s]'
+                  type: string
+                bpfLogLevel:
+                  description: 'BPFLogLevel controls the log level of the BPF programs
+                  when in BPF dataplane mode.  One of "Off", "Info", or "Debug".  The
+                  logs are emitted to the BPF trace pipe, accessible with the command
+                  `tc exec bpf debug`. [Default: Off].'
+                  type: string
+                chainInsertMode:
+                  description: 'ChainInsertMode controls whether Felix hooks the kernel''s
+                  top-level iptables chains by inserting a rule at the top of the
+                  chain or by appending a rule at the bottom. insert is the safe default
+                  since it prevents Calico''s rules from being bypassed. If you switch
+                  to append mode, be sure that the other rules in the chains signal
+                  acceptance by falling through to the Calico rules, otherwise the
+                  Calico policy will be bypassed. [Default: insert]'
+                  type: string
+                dataplaneDriver:
+                  type: string
+                debugDisableLogDropping:
+                  type: boolean
+                debugMemoryProfilePath:
+                  type: string
+                debugSimulateCalcGraphHangAfter:
+                  type: string
+                debugSimulateDataplaneHangAfter:
+                  type: string
+                defaultEndpointToHostAction:
+                  description: 'DefaultEndpointToHostAction controls what happens to
+                  traffic that goes from a workload endpoint to the host itself (after
+                  the traffic hits the endpoint egress policy). By default Calico
+                  blocks traffic from workload endpoints to the host itself with an
+                  iptables "DROP" action. If you want to allow some or all traffic
+                  from endpoint to host, set this parameter to RETURN or ACCEPT. Use
+                  RETURN if you have your own rules in the iptables "INPUT" chain;
+                  Calico will insert its rules at the top of that chain, then "RETURN"
+                  packets to the "INPUT" chain once it has completed processing workload
+                  endpoint egress policy. Use ACCEPT to unconditionally accept packets
+                  from workloads after processing workload endpoint egress policy.
+                  [Default: Drop]'
+                  type: string
+                deviceRouteProtocol:
+                  description: This defines the route protocol added to programmed device
+                    routes, by default this will be RTPROT_BOOT when left blank.
+                  type: integer
+                deviceRouteSourceAddress:
+                  description: This is the source address to use on programmed device
+                    routes. By default the source address is left blank, leaving the
+                    kernel to choose the source address used.
+                  type: string
+                disableConntrackInvalidCheck:
+                  type: boolean
+                endpointReportingDelay:
+                  type: string
+                endpointReportingEnabled:
+                  type: boolean
+                externalNodesList:
+                  description: ExternalNodesCIDRList is a list of CIDR's of external-non-calico-nodes
+                    which may source tunnel traffic and have the tunneled traffic be
+                    accepted at calico nodes.
+                  items:
+                    type: string
+                  type: array
+                failsafeInboundHostPorts:
+                  description: 'FailsafeInboundHostPorts is a list of UDP/TCP ports
+                  and CIDRs that Felix will allow incoming traffic to host endpoints
+                  on irrespective of the security policy. This is useful to avoid
+                  accidentally cutting off a host with incorrect configuration. For
+                  back-compatibility, if the protocol is not specified, it defaults
+                  to "tcp". If a CIDR is not specified, it will allow traffic from
+                  all addresses. To disable all inbound host ports, use the value
+                  none. The default value allows ssh access and DHCP. [Default: tcp:22,
+                  udp:68, tcp:179, tcp:2379, tcp:2380, tcp:6443, tcp:6666, tcp:6667]'
+                  items:
+                    description: ProtoPort is combination of protocol, port, and CIDR.
+                      Protocol and port must be specified.
+                    properties:
+                      net:
+                        type: string
+                      port:
+                        type: integer
+                      protocol:
+                        type: string
+                    required:
+                      - port
+                      - protocol
+                    type: object
+                  type: array
+                failsafeOutboundHostPorts:
+                  description: 'FailsafeOutboundHostPorts is a list of UDP/TCP ports
+                  and CIDRs that Felix will allow outgoing traffic from host endpoints
+                  to irrespective of the security policy. This is useful to avoid
+                  accidentally cutting off a host with incorrect configuration. For
+                  back-compatibility, if the protocol is not specified, it defaults
+                  to "tcp". If a CIDR is not specified, it will allow traffic from
+                  all addresses. To disable all outbound host ports, use the value
+                  none. The default value opens etcd''s standard ports to ensure that
+                  Felix does not get cut off from etcd as well as allowing DHCP and
+                  DNS. [Default: tcp:179, tcp:2379, tcp:2380, tcp:6443, tcp:6666,
+                  tcp:6667, udp:53, udp:67]'
+                  items:
+                    description: ProtoPort is combination of protocol, port, and CIDR.
+                      Protocol and port must be specified.
+                    properties:
+                      net:
+                        type: string
+                      port:
+                        type: integer
+                      protocol:
+                        type: string
+                    required:
+                      - port
+                      - protocol
+                    type: object
+                  type: array
+                featureDetectOverride:
+                  description: FeatureDetectOverride is used to override the feature
+                    detection. Values are specified in a comma separated list with no
+                    spaces, example; "SNATFullyRandom=true,MASQFullyRandom=false,RestoreSupportsLock=".
+                    "true" or "false" will force the feature, empty or omitted values
+                    are auto-detected.
+                  type: string
+                genericXDPEnabled:
+                  description: 'GenericXDPEnabled enables Generic XDP so network cards
+                  that don''t support XDP offload or driver modes can use XDP. This
+                  is not recommended since it doesn''t provide better performance
+                  than iptables. [Default: false]'
+                  type: boolean
+                healthEnabled:
+                  type: boolean
+                healthHost:
+                  type: string
+                healthPort:
+                  type: integer
+                interfaceExclude:
+                  description: 'InterfaceExclude is a comma-separated list of interfaces
+                  that Felix should exclude when monitoring for host endpoints. The
+                  default value ensures that Felix ignores Kubernetes'' IPVS dummy
+                  interface, which is used internally by kube-proxy. If you want to
+                  exclude multiple interface names using a single value, the list
+                  supports regular expressions. For regular expressions you must wrap
+                  the value with ''/''. For example having values ''/^kube/,veth1''
+                  will exclude all interfaces that begin with ''kube'' and also the
+                  interface ''veth1''. [Default: kube-ipvs0]'
+                  type: string
+                interfacePrefix:
+                  description: 'InterfacePrefix is the interface name prefix that identifies
+                  workload endpoints and so distinguishes them from host endpoint
+                  interfaces. Note: in environments other than bare metal, the orchestrators
+                  configure this appropriately. For example our Kubernetes and Docker
+                  integrations set the ''cali'' value, and our OpenStack integration
+                  sets the ''tap'' value. [Default: cali]'
+                  type: string
+                interfaceRefreshInterval:
+                  description: InterfaceRefreshInterval is the period at which Felix
+                    rescans local interfaces to verify their state. The rescan can be
+                    disabled by setting the interval to 0.
+                  type: string
+                ipipEnabled:
+                  type: boolean
+                ipipMTU:
+                  description: 'IPIPMTU is the MTU to set on the tunnel device. See
+                  Configuring MTU [Default: 1440]'
+                  type: integer
+                ipsetsRefreshInterval:
+                  description: 'IpsetsRefreshInterval is the period at which Felix re-checks
+                  all iptables state to ensure that no other process has accidentally
+                  broken Calico''s rules. Set to 0 to disable iptables refresh. [Default:
+                  90s]'
+                  type: string
+                iptablesBackend:
+                  description: IptablesBackend specifies which backend of iptables will
+                    be used. The default is legacy.
+                  type: string
+                iptablesFilterAllowAction:
+                  type: string
+                iptablesLockFilePath:
+                  description: 'IptablesLockFilePath is the location of the iptables
+                  lock file. You may need to change this if the lock file is not in
+                  its standard location (for example if you have mapped it into Felix''s
+                  container at a different path). [Default: /run/xtables.lock]'
+                  type: string
+                iptablesLockProbeInterval:
+                  description: 'IptablesLockProbeInterval is the time that Felix will
+                  wait between attempts to acquire the iptables lock if it is not
+                  available. Lower values make Felix more responsive when the lock
+                  is contended, but use more CPU. [Default: 50ms]'
+                  type: string
+                iptablesLockTimeout:
+                  description: 'IptablesLockTimeout is the time that Felix will wait
+                  for the iptables lock, or 0, to disable. To use this feature, Felix
+                  must share the iptables lock file with all other processes that
+                  also take the lock. When running Felix inside a container, this
+                  requires the /run directory of the host to be mounted into the calico/node
+                  or calico/felix container. [Default: 0s disabled]'
+                  type: string
+                iptablesMangleAllowAction:
+                  type: string
+                iptablesMarkMask:
+                  description: 'IptablesMarkMask is the mask that Felix selects its
+                  IPTables Mark bits from. Should be a 32 bit hexadecimal number with
+                  at least 8 bits set, none of which clash with any other mark bits
+                  in use on the system. [Default: 0xff000000]'
+                  format: int32
+                  type: integer
+                iptablesNATOutgoingInterfaceFilter:
+                  type: string
+                iptablesPostWriteCheckInterval:
+                  description: 'IptablesPostWriteCheckInterval is the period after Felix
+                  has done a write to the dataplane that it schedules an extra read
+                  back in order to check the write was not clobbered by another process.
+                  This should only occur if another application on the system doesn''t
+                  respect the iptables lock. [Default: 1s]'
+                  type: string
+                iptablesRefreshInterval:
+                  description: 'IptablesRefreshInterval is the period at which Felix
+                  re-checks the IP sets in the dataplane to ensure that no other process
+                  has accidentally broken Calico''s rules. Set to 0 to disable IP
+                  sets refresh. Note: the default for this value is lower than the
+                  other refresh intervals as a workaround for a Linux kernel bug that
+                  was fixed in kernel version 4.11. If you are using v4.11 or greater
+                  you may want to set this to, a higher value to reduce Felix CPU
+                  usage. [Default: 10s]'
+                  type: string
+                ipv6Support:
+                  type: boolean
+                kubeNodePortRanges:
+                  description: 'KubeNodePortRanges holds list of port ranges used for
+                  service node ports. Only used if felix detects kube-proxy running
+                  in ipvs mode. Felix uses these ranges to separate host and workload
+                  traffic. [Default: 30000:32767].'
+                  items:
+                    anyOf:
+                      - type: integer
+                      - type: string
+                    pattern: ^.*
+                    x-kubernetes-int-or-string: true
+                  type: array
+                logFilePath:
+                  description: 'LogFilePath is the full path to the Felix log. Set to
+                  none to disable file logging. [Default: /var/log/calico/felix.log]'
+                  type: string
+                logPrefix:
+                  description: 'LogPrefix is the log prefix that Felix uses when rendering
+                  LOG rules. [Default: calico-packet]'
+                  type: string
+                logSeverityFile:
+                  description: 'LogSeverityFile is the log severity above which logs
+                  are sent to the log file. [Default: Info]'
+                  type: string
+                logSeverityScreen:
+                  description: 'LogSeverityScreen is the log severity above which logs
+                  are sent to the stdout. [Default: Info]'
+                  type: string
+                logSeveritySys:
+                  description: 'LogSeveritySys is the log severity above which logs
+                  are sent to the syslog. Set to None for no logging to syslog. [Default:
+                  Info]'
+                  type: string
+                maxIpsetSize:
+                  type: integer
+                metadataAddr:
+                  description: 'MetadataAddr is the IP address or domain name of the
+                  server that can answer VM queries for cloud-init metadata. In OpenStack,
+                  this corresponds to the machine running nova-api (or in Ubuntu,
+                  nova-api-metadata). A value of none (case insensitive) means that
+                  Felix should not set up any NAT rule for the metadata path. [Default:
+                  127.0.0.1]'
+                  type: string
+                metadataPort:
+                  description: 'MetadataPort is the port of the metadata server. This,
+                  combined with global.MetadataAddr (if not ''None''), is used to
+                  set up a NAT rule, from 169.254.169.254:80 to MetadataAddr:MetadataPort.
+                  In most cases this should not need to be changed [Default: 8775].'
+                  type: integer
+                mtuIfacePattern:
+                  description: MTUIfacePattern is a regular expression that controls
+                    which interfaces Felix should scan in order to calculate the host's
+                    MTU. This should not match workload interfaces (usually named cali...).
+                  type: string
+                natOutgoingAddress:
+                  description: NATOutgoingAddress specifies an address to use when performing
+                    source NAT for traffic in a natOutgoing pool that is leaving the
+                    network. By default the address used is an address on the interface
+                    the traffic is leaving on (ie it uses the iptables MASQUERADE target)
+                  type: string
+                natPortRange:
+                  anyOf:
+                    - type: integer
+                    - type: string
+                  description: NATPortRange specifies the range of ports that is used
+                    for port mapping when doing outgoing NAT. When unset the default
+                    behavior of the network stack is used.
+                  pattern: ^.*
+                  x-kubernetes-int-or-string: true
+                netlinkTimeout:
+                  type: string
+                openstackRegion:
+                  description: 'OpenstackRegion is the name of the region that a particular
+                  Felix belongs to. In a multi-region Calico/OpenStack deployment,
+                  this must be configured somehow for each Felix (here in the datamodel,
+                  or in felix.cfg or the environment on each compute node), and must
+                  match the [calico] openstack_region value configured in neutron.conf
+                  on each node. [Default: Empty]'
+                  type: string
+                policySyncPathPrefix:
+                  description: 'PolicySyncPathPrefix is used to by Felix to communicate
+                  policy changes to external services, like Application layer policy.
+                  [Default: Empty]'
+                  type: string
+                prometheusGoMetricsEnabled:
+                  description: 'PrometheusGoMetricsEnabled disables Go runtime metrics
+                  collection, which the Prometheus client does by default, when set
+                  to false. This reduces the number of metrics reported, reducing
+                  Prometheus load. [Default: true]'
+                  type: boolean
+                prometheusMetricsEnabled:
+                  description: 'PrometheusMetricsEnabled enables the Prometheus metrics
+                  server in Felix if set to true. [Default: false]'
+                  type: boolean
+                prometheusMetricsHost:
+                  description: 'PrometheusMetricsHost is the host that the Prometheus
+                  metrics server should bind to. [Default: empty]'
+                  type: string
+                prometheusMetricsPort:
+                  description: 'PrometheusMetricsPort is the TCP port that the Prometheus
+                  metrics server should bind to. [Default: 9091]'
+                  type: integer
+                prometheusProcessMetricsEnabled:
+                  description: 'PrometheusProcessMetricsEnabled disables process metrics
+                  collection, which the Prometheus client does by default, when set
+                  to false. This reduces the number of metrics reported, reducing
+                  Prometheus load. [Default: true]'
+                  type: boolean
+                removeExternalRoutes:
+                  description: Whether or not to remove device routes that have not
+                    been programmed by Felix. Disabling this will allow external applications
+                    to also add device routes. This is enabled by default which means
+                    we will remove externally added routes.
+                  type: boolean
+                reportingInterval:
+                  description: 'ReportingInterval is the interval at which Felix reports
+                  its status into the datastore or 0 to disable. Must be non-zero
+                  in OpenStack deployments. [Default: 30s]'
+                  type: string
+                reportingTTL:
+                  description: 'ReportingTTL is the time-to-live setting for process-wide
+                  status reports. [Default: 90s]'
+                  type: string
+                routeRefreshInterval:
+                  description: 'RouteRefreshInterval is the period at which Felix re-checks
+                  the routes in the dataplane to ensure that no other process has
+                  accidentally broken Calico''s rules. Set to 0 to disable route refresh.
+                  [Default: 90s]'
+                  type: string
+                routeSource:
+                  description: 'RouteSource configures where Felix gets its routing
+                  information. - WorkloadIPs: use workload endpoints to construct
+                  routes. - CalicoIPAM: the default - use IPAM data to construct routes.'
+                  type: string
+                routeTableRange:
+                  description: Calico programs additional Linux route tables for various
+                    purposes.  RouteTableRange specifies the indices of the route tables
+                    that Calico should use.
+                  properties:
+                    max:
+                      type: integer
+                    min:
+                      type: integer
+                  required:
+                    - max
+                    - min
+                  type: object
+                serviceLoopPrevention:
+                  description: 'When service IP advertisement is enabled, prevent routing
+                  loops to service IPs that are not in use, by dropping or rejecting
+                  packets that do not get DNAT''d by kube-proxy. Unless set to "Disabled",
+                  in which case such routing loops continue to be allowed. [Default:
+                  Drop]'
+                  type: string
+                sidecarAccelerationEnabled:
+                  description: 'SidecarAccelerationEnabled enables experimental sidecar
+                  acceleration [Default: false]'
+                  type: boolean
+                usageReportingEnabled:
+                  description: 'UsageReportingEnabled reports anonymous Calico version
+                  number and cluster size to projectcalico.org. Logs warnings returned
+                  by the usage server. For example, if a significant security vulnerability
+                  has been discovered in the version of Calico being used. [Default:
+                  true]'
+                  type: boolean
+                usageReportingInitialDelay:
+                  description: 'UsageReportingInitialDelay controls the minimum delay
+                  before Felix makes a report. [Default: 300s]'
+                  type: string
+                usageReportingInterval:
+                  description: 'UsageReportingInterval controls the interval at which
+                  Felix makes reports. [Default: 86400s]'
+                  type: string
+                useInternalDataplaneDriver:
+                  type: boolean
+                vxlanEnabled:
+                  type: boolean
+                vxlanMTU:
+                  description: 'VXLANMTU is the MTU to set on the tunnel device. See
+                  Configuring MTU [Default: 1440]'
+                  type: integer
+                vxlanPort:
+                  type: integer
+                vxlanVNI:
+                  type: integer
+                wireguardEnabled:
+                  description: 'WireguardEnabled controls whether Wireguard is enabled.
+                  [Default: false]'
+                  type: boolean
+                wireguardInterfaceName:
+                  description: 'WireguardInterfaceName specifies the name to use for
+                  the Wireguard interface. [Default: wg.calico]'
+                  type: string
+                wireguardListeningPort:
+                  description: 'WireguardListeningPort controls the listening port used
+                  by Wireguard. [Default: 51820]'
+                  type: integer
+                wireguardMTU:
+                  description: 'WireguardMTU controls the MTU on the Wireguard interface.
+                  See Configuring MTU [Default: 1420]'
+                  type: integer
+                wireguardRoutingRulePriority:
+                  description: 'WireguardRoutingRulePriority controls the priority value
+                  to use for the Wireguard routing rule. [Default: 99]'
+                  type: integer
+                xdpEnabled:
+                  description: 'XDPEnabled enables XDP acceleration for suitable untracked
+                  incoming deny rules. [Default: true]'
+                  type: boolean
+                xdpRefreshInterval:
+                  description: 'XDPRefreshInterval is the period at which Felix re-checks
+                  all XDP state to ensure that no other process has accidentally broken
+                  Calico''s BPF maps or attached programs. Set to 0 to disable XDP
+                  refresh. [Default: 90s]'
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: globalnetworkpolicies.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: GlobalNetworkPolicy
+    listKind: GlobalNetworkPolicyList
+    plural: globalnetworkpolicies
+    singular: globalnetworkpolicy
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                applyOnForward:
+                  description: ApplyOnForward indicates to apply the rules in this policy
+                    on forward traffic.
+                  type: boolean
+                doNotTrack:
+                  description: DoNotTrack indicates whether packets matched by the rules
+                    in this policy should go through the data plane's connection tracking,
+                    such as Linux conntrack.  If True, the rules in this policy are
+                    applied before any data plane connection tracking, and packets allowed
+                    by this policy are marked as not to be tracked.
+                  type: boolean
+                egress:
+                  description: The ordered set of egress rules.  Each rule contains
+                    a set of packet match criteria and a corresponding action to apply.
+                  items:
+                    description: "A Rule encapsulates a set of match criteria and an
+                    action.  Both selector-based security Policy and security Profiles
+                    reference rules - separated out as a list of rules for both ingress
+                    and egress packet matching. \n Each positive match criteria has
+                    a negated version, prefixed with \"Not\". All the match criteria
+                    within a rule must be satisfied for a packet to match. A single
+                    rule can contain the positive and negative version of a match
+                    and both must be satisfied for the rule to match."
+                    properties:
+                      action:
+                        type: string
+                      destination:
+                        description: Destination contains the match criteria that apply
+                          to destination entity.
+                        properties:
+                          namespaceSelector:
+                            description: "NamespaceSelector is an optional field that
+                            contains a selector expression. Only traffic that originates
+                            from (or terminates at) endpoints within the selected
+                            namespaces will be matched. When both NamespaceSelector
+                            and another selector are defined on the same rule, then
+                            only workload endpoints that are matched by both selectors
+                            will be selected by the rule. \n For NetworkPolicy, an
+                            empty NamespaceSelector implies that the Selector is limited
+                            to selecting only workload endpoints in the same namespace
+                            as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                            NamespaceSelector implies that the Selector is limited
+                            to selecting only GlobalNetworkSet or HostEndpoint. \n
+                            For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                            the Selector applies to workload endpoints across all
+                            namespaces."
+                            type: string
+                          nets:
+                            description: Nets is an optional field that restricts the
+                              rule to only apply to traffic that originates from (or
+                              terminates at) IP addresses in any of the given subnets.
+                            items:
+                              type: string
+                            type: array
+                          notNets:
+                            description: NotNets is the negated version of the Nets
+                              field.
+                            items:
+                              type: string
+                            type: array
+                          notPorts:
+                            description: NotPorts is the negated version of the Ports
+                              field. Since only some protocols have ports, if any ports
+                              are specified it requires the Protocol match in the Rule
+                              to be set to "TCP" or "UDP".
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          notSelector:
+                            description: NotSelector is the negated version of the Selector
+                              field.  See Selector field for subtleties with negated
+                              selectors.
+                            type: string
+                          ports:
+                            description: "Ports is an optional field that restricts
+                            the rule to only apply to traffic that has a source (destination)
+                            port that matches one of these ranges/values. This value
+                            is a list of integers or strings that represent ranges
+                            of ports. \n Since only some protocols have ports, if
+                            any ports are specified it requires the Protocol match
+                            in the Rule to be set to \"TCP\" or \"UDP\"."
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          selector:
+                            description: "Selector is an optional field that contains
+                            a selector expression (see Policy for sample syntax).
+                            \ Only traffic that originates from (terminates at) endpoints
+                            matching the selector will be matched. \n Note that: in
+                            addition to the negated version of the Selector (see NotSelector
+                            below), the selector expression syntax itself supports
+                            negation.  The two types of negation are subtly different.
+                            One negates the set of matched endpoints, the other negates
+                            the whole match: \n \tSelector = \"!has(my_label)\" matches
+                            packets that are from other Calico-controlled \tendpoints
+                            that do not have the label \"my_label\". \n \tNotSelector
+                            = \"has(my_label)\" matches packets that are not from
+                            Calico-controlled \tendpoints that do have the label \"my_label\".
+                            \n The effect is that the latter will accept packets from
+                            non-Calico sources whereas the former is limited to packets
+                            from Calico-controlled endpoints."
+                            type: string
+                          serviceAccounts:
+                            description: ServiceAccounts is an optional field that restricts
+                              the rule to only apply to traffic that originates from
+                              (or terminates at) a pod running as a matching service
+                              account.
+                            properties:
+                              names:
+                                description: Names is an optional field that restricts
+                                  the rule to only apply to traffic that originates
+                                  from (or terminates at) a pod running as a service
+                                  account whose name is in the list.
+                                items:
+                                  type: string
+                                type: array
+                              selector:
+                                description: Selector is an optional field that restricts
+                                  the rule to only apply to traffic that originates
+                                  from (or terminates at) a pod running as a service
+                                  account that matches the given label selector. If
+                                  both Names and Selector are specified then they are
+                                  AND'ed.
+                                type: string
+                            type: object
+                          services:
+                            description: "Services is an optional field that contains
+                            options for matching Kubernetes Services. If specified,
+                            only traffic that originates from or terminates at endpoints
+                            within the selected service(s) will be matched, and only
+                            to/from each endpoint's port. \n Services cannot be specified
+                            on the same rule as Selector, NotSelector, NamespaceSelector,
+                            Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                            Only valid on egress rules."
+                            properties:
+                              name:
+                                description: Name specifies the name of a Kubernetes
+                                  Service to match.
+                                type: string
+                              namespace:
+                                description: Namespace specifies the namespace of the
+                                  given Service. If left empty, the rule will match
+                                  within this policy's namespace.
+                                type: string
+                            type: object
+                        type: object
+                      http:
+                        description: HTTP contains match criteria that apply to HTTP
+                          requests.
+                        properties:
+                          methods:
+                            description: Methods is an optional field that restricts
+                              the rule to apply only to HTTP requests that use one of
+                              the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
+                              methods are OR'd together.
+                            items:
+                              type: string
+                            type: array
+                          paths:
+                            description: 'Paths is an optional field that restricts
+                            the rule to apply to HTTP requests that use one of the
+                            listed HTTP Paths. Multiple paths are OR''d together.
+                            e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
+                            ONLY specify either a `exact` or a `prefix` match. The
+                            validator will check for it.'
+                            items:
+                              description: 'HTTPPath specifies an HTTP path to match.
+                              It may be either of the form: exact: <path>: which matches
+                              the path exactly or prefix: <path-prefix>: which matches
+                              the path prefix'
+                              properties:
+                                exact:
+                                  type: string
+                                prefix:
+                                  type: string
+                              type: object
+                            type: array
+                        type: object
+                      icmp:
+                        description: ICMP is an optional field that restricts the rule
+                          to apply to a specific type and code of ICMP traffic.  This
+                          should only be specified if the Protocol field is set to "ICMP"
+                          or "ICMPv6".
+                        properties:
+                          code:
+                            description: Match on a specific ICMP code.  If specified,
+                              the Type value must also be specified. This is a technical
+                              limitation imposed by the kernel's iptables firewall,
+                              which Calico uses to enforce the rule.
+                            type: integer
+                          type:
+                            description: Match on a specific ICMP type.  For example
+                              a value of 8 refers to ICMP Echo Request (i.e. pings).
+                            type: integer
+                        type: object
+                      ipVersion:
+                        description: IPVersion is an optional field that restricts the
+                          rule to only match a specific IP version.
+                        type: integer
+                      metadata:
+                        description: Metadata contains additional information for this
+                          rule
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            description: Annotations is a set of key value pairs that
+                              give extra information about the rule
+                            type: object
+                        type: object
+                      notICMP:
+                        description: NotICMP is the negated version of the ICMP field.
+                        properties:
+                          code:
+                            description: Match on a specific ICMP code.  If specified,
+                              the Type value must also be specified. This is a technical
+                              limitation imposed by the kernel's iptables firewall,
+                              which Calico uses to enforce the rule.
+                            type: integer
+                          type:
+                            description: Match on a specific ICMP type.  For example
+                              a value of 8 refers to ICMP Echo Request (i.e. pings).
+                            type: integer
+                        type: object
+                      notProtocol:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        description: NotProtocol is the negated version of the Protocol
+                          field.
+                        pattern: ^.*
+                        x-kubernetes-int-or-string: true
+                      protocol:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        description: "Protocol is an optional field that restricts the
+                        rule to only apply to traffic of a specific IP protocol. Required
+                        if any of the EntityRules contain Ports (because ports only
+                        apply to certain protocols). \n Must be one of these string
+                        values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
+                        \"UDPLite\" or an integer in the range 1-255."
+                        pattern: ^.*
+                        x-kubernetes-int-or-string: true
+                      source:
+                        description: Source contains the match criteria that apply to
+                          source entity.
+                        properties:
+                          namespaceSelector:
+                            description: "NamespaceSelector is an optional field that
+                            contains a selector expression. Only traffic that originates
+                            from (or terminates at) endpoints within the selected
+                            namespaces will be matched. When both NamespaceSelector
+                            and another selector are defined on the same rule, then
+                            only workload endpoints that are matched by both selectors
+                            will be selected by the rule. \n For NetworkPolicy, an
+                            empty NamespaceSelector implies that the Selector is limited
+                            to selecting only workload endpoints in the same namespace
+                            as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                            NamespaceSelector implies that the Selector is limited
+                            to selecting only GlobalNetworkSet or HostEndpoint. \n
+                            For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                            the Selector applies to workload endpoints across all
+                            namespaces."
+                            type: string
+                          nets:
+                            description: Nets is an optional field that restricts the
+                              rule to only apply to traffic that originates from (or
+                              terminates at) IP addresses in any of the given subnets.
+                            items:
+                              type: string
+                            type: array
+                          notNets:
+                            description: NotNets is the negated version of the Nets
+                              field.
+                            items:
+                              type: string
+                            type: array
+                          notPorts:
+                            description: NotPorts is the negated version of the Ports
+                              field. Since only some protocols have ports, if any ports
+                              are specified it requires the Protocol match in the Rule
+                              to be set to "TCP" or "UDP".
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          notSelector:
+                            description: NotSelector is the negated version of the Selector
+                              field.  See Selector field for subtleties with negated
+                              selectors.
+                            type: string
+                          ports:
+                            description: "Ports is an optional field that restricts
+                            the rule to only apply to traffic that has a source (destination)
+                            port that matches one of these ranges/values. This value
+                            is a list of integers or strings that represent ranges
+                            of ports. \n Since only some protocols have ports, if
+                            any ports are specified it requires the Protocol match
+                            in the Rule to be set to \"TCP\" or \"UDP\"."
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          selector:
+                            description: "Selector is an optional field that contains
+                            a selector expression (see Policy for sample syntax).
+                            \ Only traffic that originates from (terminates at) endpoints
+                            matching the selector will be matched. \n Note that: in
+                            addition to the negated version of the Selector (see NotSelector
+                            below), the selector expression syntax itself supports
+                            negation.  The two types of negation are subtly different.
+                            One negates the set of matched endpoints, the other negates
+                            the whole match: \n \tSelector = \"!has(my_label)\" matches
+                            packets that are from other Calico-controlled \tendpoints
+                            that do not have the label \"my_label\". \n \tNotSelector
+                            = \"has(my_label)\" matches packets that are not from
+                            Calico-controlled \tendpoints that do have the label \"my_label\".
+                            \n The effect is that the latter will accept packets from
+                            non-Calico sources whereas the former is limited to packets
+                            from Calico-controlled endpoints."
+                            type: string
+                          serviceAccounts:
+                            description: ServiceAccounts is an optional field that restricts
+                              the rule to only apply to traffic that originates from
+                              (or terminates at) a pod running as a matching service
+                              account.
+                            properties:
+                              names:
+                                description: Names is an optional field that restricts
+                                  the rule to only apply to traffic that originates
+                                  from (or terminates at) a pod running as a service
+                                  account whose name is in the list.
+                                items:
+                                  type: string
+                                type: array
+                              selector:
+                                description: Selector is an optional field that restricts
+                                  the rule to only apply to traffic that originates
+                                  from (or terminates at) a pod running as a service
+                                  account that matches the given label selector. If
+                                  both Names and Selector are specified then they are
+                                  AND'ed.
+                                type: string
+                            type: object
+                          services:
+                            description: "Services is an optional field that contains
+                            options for matching Kubernetes Services. If specified,
+                            only traffic that originates from or terminates at endpoints
+                            within the selected service(s) will be matched, and only
+                            to/from each endpoint's port. \n Services cannot be specified
+                            on the same rule as Selector, NotSelector, NamespaceSelector,
+                            Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                            Only valid on egress rules."
+                            properties:
+                              name:
+                                description: Name specifies the name of a Kubernetes
+                                  Service to match.
+                                type: string
+                              namespace:
+                                description: Namespace specifies the namespace of the
+                                  given Service. If left empty, the rule will match
+                                  within this policy's namespace.
+                                type: string
+                            type: object
+                        type: object
+                    required:
+                      - action
+                    type: object
+                  type: array
+                ingress:
+                  description: The ordered set of ingress rules.  Each rule contains
+                    a set of packet match criteria and a corresponding action to apply.
+                  items:
+                    description: "A Rule encapsulates a set of match criteria and an
+                    action.  Both selector-based security Policy and security Profiles
+                    reference rules - separated out as a list of rules for both ingress
+                    and egress packet matching. \n Each positive match criteria has
+                    a negated version, prefixed with \"Not\". All the match criteria
+                    within a rule must be satisfied for a packet to match. A single
+                    rule can contain the positive and negative version of a match
+                    and both must be satisfied for the rule to match."
+                    properties:
+                      action:
+                        type: string
+                      destination:
+                        description: Destination contains the match criteria that apply
+                          to destination entity.
+                        properties:
+                          namespaceSelector:
+                            description: "NamespaceSelector is an optional field that
+                            contains a selector expression. Only traffic that originates
+                            from (or terminates at) endpoints within the selected
+                            namespaces will be matched. When both NamespaceSelector
+                            and another selector are defined on the same rule, then
+                            only workload endpoints that are matched by both selectors
+                            will be selected by the rule. \n For NetworkPolicy, an
+                            empty NamespaceSelector implies that the Selector is limited
+                            to selecting only workload endpoints in the same namespace
+                            as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                            NamespaceSelector implies that the Selector is limited
+                            to selecting only GlobalNetworkSet or HostEndpoint. \n
+                            For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                            the Selector applies to workload endpoints across all
+                            namespaces."
+                            type: string
+                          nets:
+                            description: Nets is an optional field that restricts the
+                              rule to only apply to traffic that originates from (or
+                              terminates at) IP addresses in any of the given subnets.
+                            items:
+                              type: string
+                            type: array
+                          notNets:
+                            description: NotNets is the negated version of the Nets
+                              field.
+                            items:
+                              type: string
+                            type: array
+                          notPorts:
+                            description: NotPorts is the negated version of the Ports
+                              field. Since only some protocols have ports, if any ports
+                              are specified it requires the Protocol match in the Rule
+                              to be set to "TCP" or "UDP".
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          notSelector:
+                            description: NotSelector is the negated version of the Selector
+                              field.  See Selector field for subtleties with negated
+                              selectors.
+                            type: string
+                          ports:
+                            description: "Ports is an optional field that restricts
+                            the rule to only apply to traffic that has a source (destination)
+                            port that matches one of these ranges/values. This value
+                            is a list of integers or strings that represent ranges
+                            of ports. \n Since only some protocols have ports, if
+                            any ports are specified it requires the Protocol match
+                            in the Rule to be set to \"TCP\" or \"UDP\"."
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          selector:
+                            description: "Selector is an optional field that contains
+                            a selector expression (see Policy for sample syntax).
+                            \ Only traffic that originates from (terminates at) endpoints
+                            matching the selector will be matched. \n Note that: in
+                            addition to the negated version of the Selector (see NotSelector
+                            below), the selector expression syntax itself supports
+                            negation.  The two types of negation are subtly different.
+                            One negates the set of matched endpoints, the other negates
+                            the whole match: \n \tSelector = \"!has(my_label)\" matches
+                            packets that are from other Calico-controlled \tendpoints
+                            that do not have the label \"my_label\". \n \tNotSelector
+                            = \"has(my_label)\" matches packets that are not from
+                            Calico-controlled \tendpoints that do have the label \"my_label\".
+                            \n The effect is that the latter will accept packets from
+                            non-Calico sources whereas the former is limited to packets
+                            from Calico-controlled endpoints."
+                            type: string
+                          serviceAccounts:
+                            description: ServiceAccounts is an optional field that restricts
+                              the rule to only apply to traffic that originates from
+                              (or terminates at) a pod running as a matching service
+                              account.
+                            properties:
+                              names:
+                                description: Names is an optional field that restricts
+                                  the rule to only apply to traffic that originates
+                                  from (or terminates at) a pod running as a service
+                                  account whose name is in the list.
+                                items:
+                                  type: string
+                                type: array
+                              selector:
+                                description: Selector is an optional field that restricts
+                                  the rule to only apply to traffic that originates
+                                  from (or terminates at) a pod running as a service
+                                  account that matches the given label selector. If
+                                  both Names and Selector are specified then they are
+                                  AND'ed.
+                                type: string
+                            type: object
+                          services:
+                            description: "Services is an optional field that contains
+                            options for matching Kubernetes Services. If specified,
+                            only traffic that originates from or terminates at endpoints
+                            within the selected service(s) will be matched, and only
+                            to/from each endpoint's port. \n Services cannot be specified
+                            on the same rule as Selector, NotSelector, NamespaceSelector,
+                            Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                            Only valid on egress rules."
+                            properties:
+                              name:
+                                description: Name specifies the name of a Kubernetes
+                                  Service to match.
+                                type: string
+                              namespace:
+                                description: Namespace specifies the namespace of the
+                                  given Service. If left empty, the rule will match
+                                  within this policy's namespace.
+                                type: string
+                            type: object
+                        type: object
+                      http:
+                        description: HTTP contains match criteria that apply to HTTP
+                          requests.
+                        properties:
+                          methods:
+                            description: Methods is an optional field that restricts
+                              the rule to apply only to HTTP requests that use one of
+                              the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
+                              methods are OR'd together.
+                            items:
+                              type: string
+                            type: array
+                          paths:
+                            description: 'Paths is an optional field that restricts
+                            the rule to apply to HTTP requests that use one of the
+                            listed HTTP Paths. Multiple paths are OR''d together.
+                            e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
+                            ONLY specify either a `exact` or a `prefix` match. The
+                            validator will check for it.'
+                            items:
+                              description: 'HTTPPath specifies an HTTP path to match.
+                              It may be either of the form: exact: <path>: which matches
+                              the path exactly or prefix: <path-prefix>: which matches
+                              the path prefix'
+                              properties:
+                                exact:
+                                  type: string
+                                prefix:
+                                  type: string
+                              type: object
+                            type: array
+                        type: object
+                      icmp:
+                        description: ICMP is an optional field that restricts the rule
+                          to apply to a specific type and code of ICMP traffic.  This
+                          should only be specified if the Protocol field is set to "ICMP"
+                          or "ICMPv6".
+                        properties:
+                          code:
+                            description: Match on a specific ICMP code.  If specified,
+                              the Type value must also be specified. This is a technical
+                              limitation imposed by the kernel's iptables firewall,
+                              which Calico uses to enforce the rule.
+                            type: integer
+                          type:
+                            description: Match on a specific ICMP type.  For example
+                              a value of 8 refers to ICMP Echo Request (i.e. pings).
+                            type: integer
+                        type: object
+                      ipVersion:
+                        description: IPVersion is an optional field that restricts the
+                          rule to only match a specific IP version.
+                        type: integer
+                      metadata:
+                        description: Metadata contains additional information for this
+                          rule
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            description: Annotations is a set of key value pairs that
+                              give extra information about the rule
+                            type: object
+                        type: object
+                      notICMP:
+                        description: NotICMP is the negated version of the ICMP field.
+                        properties:
+                          code:
+                            description: Match on a specific ICMP code.  If specified,
+                              the Type value must also be specified. This is a technical
+                              limitation imposed by the kernel's iptables firewall,
+                              which Calico uses to enforce the rule.
+                            type: integer
+                          type:
+                            description: Match on a specific ICMP type.  For example
+                              a value of 8 refers to ICMP Echo Request (i.e. pings).
+                            type: integer
+                        type: object
+                      notProtocol:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        description: NotProtocol is the negated version of the Protocol
+                          field.
+                        pattern: ^.*
+                        x-kubernetes-int-or-string: true
+                      protocol:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        description: "Protocol is an optional field that restricts the
+                        rule to only apply to traffic of a specific IP protocol. Required
+                        if any of the EntityRules contain Ports (because ports only
+                        apply to certain protocols). \n Must be one of these string
+                        values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
+                        \"UDPLite\" or an integer in the range 1-255."
+                        pattern: ^.*
+                        x-kubernetes-int-or-string: true
+                      source:
+                        description: Source contains the match criteria that apply to
+                          source entity.
+                        properties:
+                          namespaceSelector:
+                            description: "NamespaceSelector is an optional field that
+                            contains a selector expression. Only traffic that originates
+                            from (or terminates at) endpoints within the selected
+                            namespaces will be matched. When both NamespaceSelector
+                            and another selector are defined on the same rule, then
+                            only workload endpoints that are matched by both selectors
+                            will be selected by the rule. \n For NetworkPolicy, an
+                            empty NamespaceSelector implies that the Selector is limited
+                            to selecting only workload endpoints in the same namespace
+                            as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                            NamespaceSelector implies that the Selector is limited
+                            to selecting only GlobalNetworkSet or HostEndpoint. \n
+                            For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                            the Selector applies to workload endpoints across all
+                            namespaces."
+                            type: string
+                          nets:
+                            description: Nets is an optional field that restricts the
+                              rule to only apply to traffic that originates from (or
+                              terminates at) IP addresses in any of the given subnets.
+                            items:
+                              type: string
+                            type: array
+                          notNets:
+                            description: NotNets is the negated version of the Nets
+                              field.
+                            items:
+                              type: string
+                            type: array
+                          notPorts:
+                            description: NotPorts is the negated version of the Ports
+                              field. Since only some protocols have ports, if any ports
+                              are specified it requires the Protocol match in the Rule
+                              to be set to "TCP" or "UDP".
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          notSelector:
+                            description: NotSelector is the negated version of the Selector
+                              field.  See Selector field for subtleties with negated
+                              selectors.
+                            type: string
+                          ports:
+                            description: "Ports is an optional field that restricts
+                            the rule to only apply to traffic that has a source (destination)
+                            port that matches one of these ranges/values. This value
+                            is a list of integers or strings that represent ranges
+                            of ports. \n Since only some protocols have ports, if
+                            any ports are specified it requires the Protocol match
+                            in the Rule to be set to \"TCP\" or \"UDP\"."
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          selector:
+                            description: "Selector is an optional field that contains
+                            a selector expression (see Policy for sample syntax).
+                            \ Only traffic that originates from (terminates at) endpoints
+                            matching the selector will be matched. \n Note that: in
+                            addition to the negated version of the Selector (see NotSelector
+                            below), the selector expression syntax itself supports
+                            negation.  The two types of negation are subtly different.
+                            One negates the set of matched endpoints, the other negates
+                            the whole match: \n \tSelector = \"!has(my_label)\" matches
+                            packets that are from other Calico-controlled \tendpoints
+                            that do not have the label \"my_label\". \n \tNotSelector
+                            = \"has(my_label)\" matches packets that are not from
+                            Calico-controlled \tendpoints that do have the label \"my_label\".
+                            \n The effect is that the latter will accept packets from
+                            non-Calico sources whereas the former is limited to packets
+                            from Calico-controlled endpoints."
+                            type: string
+                          serviceAccounts:
+                            description: ServiceAccounts is an optional field that restricts
+                              the rule to only apply to traffic that originates from
+                              (or terminates at) a pod running as a matching service
+                              account.
+                            properties:
+                              names:
+                                description: Names is an optional field that restricts
+                                  the rule to only apply to traffic that originates
+                                  from (or terminates at) a pod running as a service
+                                  account whose name is in the list.
+                                items:
+                                  type: string
+                                type: array
+                              selector:
+                                description: Selector is an optional field that restricts
+                                  the rule to only apply to traffic that originates
+                                  from (or terminates at) a pod running as a service
+                                  account that matches the given label selector. If
+                                  both Names and Selector are specified then they are
+                                  AND'ed.
+                                type: string
+                            type: object
+                          services:
+                            description: "Services is an optional field that contains
+                            options for matching Kubernetes Services. If specified,
+                            only traffic that originates from or terminates at endpoints
+                            within the selected service(s) will be matched, and only
+                            to/from each endpoint's port. \n Services cannot be specified
+                            on the same rule as Selector, NotSelector, NamespaceSelector,
+                            Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                            Only valid on egress rules."
+                            properties:
+                              name:
+                                description: Name specifies the name of a Kubernetes
+                                  Service to match.
+                                type: string
+                              namespace:
+                                description: Namespace specifies the namespace of the
+                                  given Service. If left empty, the rule will match
+                                  within this policy's namespace.
+                                type: string
+                            type: object
+                        type: object
+                    required:
+                      - action
+                    type: object
+                  type: array
+                namespaceSelector:
+                  description: NamespaceSelector is an optional field for an expression
+                    used to select a pod based on namespaces.
+                  type: string
+                order:
+                  description: Order is an optional field that specifies the order in
+                    which the policy is applied. Policies with higher "order" are applied
+                    after those with lower order.  If the order is omitted, it may be
+                    considered to be "infinite" - i.e. the policy will be applied last.  Policies
+                    with identical order will be applied in alphanumerical order based
+                    on the Policy "Name".
+                  type: number
+                preDNAT:
+                  description: PreDNAT indicates to apply the rules in this policy before
+                    any DNAT.
+                  type: boolean
+                selector:
+                  description: "The selector is an expression used to pick pick out
+                  the endpoints that the policy should be applied to. \n Selector
+                  expressions follow this syntax: \n \tlabel == \"string_literal\"
+                  \ ->  comparison, e.g. my_label == \"foo bar\" \tlabel != \"string_literal\"
+                  \  ->  not equal; also matches if label is not present \tlabel in
+                  { \"a\", \"b\", \"c\", ... }  ->  true if the value of label X is
+                  one of \"a\", \"b\", \"c\" \tlabel not in { \"a\", \"b\", \"c\",
+                  ... }  ->  true if the value of label X is not one of \"a\", \"b\",
+                  \"c\" \thas(label_name)  -> True if that label is present \t! expr
+                  -> negation of expr \texpr && expr  -> Short-circuit and \texpr
+                  || expr  -> Short-circuit or \t( expr ) -> parens for grouping \tall()
+                  or the empty selector -> matches all endpoints. \n Label names are
+                  allowed to contain alphanumerics, -, _ and /. String literals are
+                  more permissive but they do not support escape characters. \n Examples
+                  (with made-up labels): \n \ttype == \"webserver\" && deployment
+                  == \"prod\" \ttype in {\"frontend\", \"backend\"} \tdeployment !=
+                  \"dev\" \t! has(label_name)"
+                  type: string
+                serviceAccountSelector:
+                  description: ServiceAccountSelector is an optional field for an expression
+                    used to select a pod based on service accounts.
+                  type: string
+                types:
+                  description: "Types indicates whether this policy applies to ingress,
+                  or to egress, or to both.  When not explicitly specified (and so
+                  the value on creation is empty or nil), Calico defaults Types according
+                  to what Ingress and Egress rules are present in the policy.  The
+                  default is: \n - [ PolicyTypeIngress ], if there are no Egress rules
+                  (including the case where there are   also no Ingress rules) \n
+                  - [ PolicyTypeEgress ], if there are Egress rules but no Ingress
+                  rules \n - [ PolicyTypeIngress, PolicyTypeEgress ], if there are
+                  both Ingress and Egress rules. \n When the policy is read back again,
+                  Types will always be one of these values, never empty or nil."
+                  items:
+                    description: PolicyType enumerates the possible values of the PolicySpec
+                      Types field.
+                    type: string
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: globalnetworksets.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: GlobalNetworkSet
+    listKind: GlobalNetworkSetList
+    plural: globalnetworksets
+    singular: globalnetworkset
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: GlobalNetworkSet contains a set of arbitrary IP sub-networks/CIDRs
+            that share labels to allow rules to refer to them via selectors.  The labels
+            of GlobalNetworkSet are not namespaced.
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: GlobalNetworkSetSpec contains the specification for a NetworkSet
+                resource.
+              properties:
+                nets:
+                  description: The list of IP networks that belong to this set.
+                  items:
+                    type: string
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: hostendpoints.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: HostEndpoint
+    listKind: HostEndpointList
+    plural: hostendpoints
+    singular: hostendpoint
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: HostEndpointSpec contains the specification for a HostEndpoint
+                resource.
+              properties:
+                expectedIPs:
+                  description: "The expected IP addresses (IPv4 and IPv6) of the endpoint.
+                  If \"InterfaceName\" is not present, Calico will look for an interface
+                  matching any of the IPs in the list and apply policy to that. Note:
+                  \tWhen using the selector match criteria in an ingress or egress
+                  security Policy \tor Profile, Calico converts the selector into
+                  a set of IP addresses. For host \tendpoints, the ExpectedIPs field
+                  is used for that purpose. (If only the interface \tname is specified,
+                  Calico does not learn the IPs of the interface for use in match
+                  \tcriteria.)"
+                  items:
+                    type: string
+                  type: array
+                interfaceName:
+                  description: "Either \"*\", or the name of a specific Linux interface
+                  to apply policy to; or empty.  \"*\" indicates that this HostEndpoint
+                  governs all traffic to, from or through the default network namespace
+                  of the host named by the \"Node\" field; entering and leaving that
+                  namespace via any interface, including those from/to non-host-networked
+                  local workloads. \n If InterfaceName is not \"*\", this HostEndpoint
+                  only governs traffic that enters or leaves the host through the
+                  specific interface named by InterfaceName, or - when InterfaceName
+                  is empty - through the specific interface that has one of the IPs
+                  in ExpectedIPs. Therefore, when InterfaceName is empty, at least
+                  one expected IP must be specified.  Only external interfaces (such
+                  as \"eth0\") are supported here; it isn't possible for a HostEndpoint
+                  to protect traffic through a specific local workload interface.
+                  \n Note: Only some kinds of policy are implemented for \"*\" HostEndpoints;
+                  initially just pre-DNAT policy.  Please check Calico documentation
+                  for the latest position."
+                  type: string
+                node:
+                  description: The node name identifying the Calico node instance.
+                  type: string
+                ports:
+                  description: Ports contains the endpoint's named ports, which may
+                    be referenced in security policy rules.
+                  items:
+                    properties:
+                      name:
+                        type: string
+                      port:
+                        type: integer
+                      protocol:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        pattern: ^.*
+                        x-kubernetes-int-or-string: true
+                    required:
+                      - name
+                      - port
+                      - protocol
+                    type: object
+                  type: array
+                profiles:
+                  description: A list of identifiers of security Profile objects that
+                    apply to this endpoint. Each profile is applied in the order that
+                    they appear in this list.  Profile rules are applied after the selector-based
+                    security policy.
+                  items:
+                    type: string
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: ippools.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: IPPool
+    listKind: IPPoolList
+    plural: ippools
+    singular: ippool
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: IPPoolSpec contains the specification for an IPPool resource.
+              properties:
+                blockSize:
+                  description: The block size to use for IP address assignments from
+                    this pool. Defaults to 26 for IPv4 and 112 for IPv6.
+                  type: integer
+                cidr:
+                  description: The pool CIDR.
+                  type: string
+                disabled:
+                  description: When disabled is true, Calico IPAM will not assign addresses
+                    from this pool.
+                  type: boolean
+                ipip:
+                  description: 'Deprecated: this field is only used for APIv1 backwards
+                  compatibility. Setting this field is not allowed, this field is
+                  for internal use only.'
+                  properties:
+                    enabled:
+                      description: When enabled is true, ipip tunneling will be used
+                        to deliver packets to destinations within this pool.
+                      type: boolean
+                    mode:
+                      description: The IPIP mode.  This can be one of "always" or "cross-subnet".  A
+                        mode of "always" will also use IPIP tunneling for routing to
+                        destination IP addresses within this pool.  A mode of "cross-subnet"
+                        will only use IPIP tunneling when the destination node is on
+                        a different subnet to the originating node.  The default value
+                        (if not specified) is "always".
+                      type: string
+                  type: object
+                ipipMode:
+                  description: Contains configuration for IPIP tunneling for this pool.
+                    If not specified, then this is defaulted to "Never" (i.e. IPIP tunneling
+                    is disabled).
+                  type: string
+                nat-outgoing:
+                  description: 'Deprecated: this field is only used for APIv1 backwards
+                  compatibility. Setting this field is not allowed, this field is
+                  for internal use only.'
+                  type: boolean
+                natOutgoing:
+                  description: When nat-outgoing is true, packets sent from Calico networked
+                    containers in this pool to destinations outside of this pool will
+                    be masqueraded.
+                  type: boolean
+                nodeSelector:
+                  description: Allows IPPool to allocate for a specific node by label
+                    selector.
+                  type: string
+                vxlanMode:
+                  description: Contains configuration for VXLAN tunneling for this pool.
+                    If not specified, then this is defaulted to "Never" (i.e. VXLAN
+                    tunneling is disabled).
+                  type: string
+              required:
+                - cidr
+              type: object
+          type: object
+      served: true
+      storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: networkpolicies.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: NetworkPolicy
+    listKind: NetworkPolicyList
+    plural: networkpolicies
+    singular: networkpolicy
+  scope: Namespaced
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                egress:
+                  description: The ordered set of egress rules.  Each rule contains
+                    a set of packet match criteria and a corresponding action to apply.
+                  items:
+                    description: "A Rule encapsulates a set of match criteria and an
+                    action.  Both selector-based security Policy and security Profiles
+                    reference rules - separated out as a list of rules for both ingress
+                    and egress packet matching. \n Each positive match criteria has
+                    a negated version, prefixed with \"Not\". All the match criteria
+                    within a rule must be satisfied for a packet to match. A single
+                    rule can contain the positive and negative version of a match
+                    and both must be satisfied for the rule to match."
+                    properties:
+                      action:
+                        type: string
+                      destination:
+                        description: Destination contains the match criteria that apply
+                          to destination entity.
+                        properties:
+                          namespaceSelector:
+                            description: "NamespaceSelector is an optional field that
+                            contains a selector expression. Only traffic that originates
+                            from (or terminates at) endpoints within the selected
+                            namespaces will be matched. When both NamespaceSelector
+                            and another selector are defined on the same rule, then
+                            only workload endpoints that are matched by both selectors
+                            will be selected by the rule. \n For NetworkPolicy, an
+                            empty NamespaceSelector implies that the Selector is limited
+                            to selecting only workload endpoints in the same namespace
+                            as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                            NamespaceSelector implies that the Selector is limited
+                            to selecting only GlobalNetworkSet or HostEndpoint. \n
+                            For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                            the Selector applies to workload endpoints across all
+                            namespaces."
+                            type: string
+                          nets:
+                            description: Nets is an optional field that restricts the
+                              rule to only apply to traffic that originates from (or
+                              terminates at) IP addresses in any of the given subnets.
+                            items:
+                              type: string
+                            type: array
+                          notNets:
+                            description: NotNets is the negated version of the Nets
+                              field.
+                            items:
+                              type: string
+                            type: array
+                          notPorts:
+                            description: NotPorts is the negated version of the Ports
+                              field. Since only some protocols have ports, if any ports
+                              are specified it requires the Protocol match in the Rule
+                              to be set to "TCP" or "UDP".
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          notSelector:
+                            description: NotSelector is the negated version of the Selector
+                              field.  See Selector field for subtleties with negated
+                              selectors.
+                            type: string
+                          ports:
+                            description: "Ports is an optional field that restricts
+                            the rule to only apply to traffic that has a source (destination)
+                            port that matches one of these ranges/values. This value
+                            is a list of integers or strings that represent ranges
+                            of ports. \n Since only some protocols have ports, if
+                            any ports are specified it requires the Protocol match
+                            in the Rule to be set to \"TCP\" or \"UDP\"."
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          selector:
+                            description: "Selector is an optional field that contains
+                            a selector expression (see Policy for sample syntax).
+                            \ Only traffic that originates from (terminates at) endpoints
+                            matching the selector will be matched. \n Note that: in
+                            addition to the negated version of the Selector (see NotSelector
+                            below), the selector expression syntax itself supports
+                            negation.  The two types of negation are subtly different.
+                            One negates the set of matched endpoints, the other negates
+                            the whole match: \n \tSelector = \"!has(my_label)\" matches
+                            packets that are from other Calico-controlled \tendpoints
+                            that do not have the label \"my_label\". \n \tNotSelector
+                            = \"has(my_label)\" matches packets that are not from
+                            Calico-controlled \tendpoints that do have the label \"my_label\".
+                            \n The effect is that the latter will accept packets from
+                            non-Calico sources whereas the former is limited to packets
+                            from Calico-controlled endpoints."
+                            type: string
+                          serviceAccounts:
+                            description: ServiceAccounts is an optional field that restricts
+                              the rule to only apply to traffic that originates from
+                              (or terminates at) a pod running as a matching service
+                              account.
+                            properties:
+                              names:
+                                description: Names is an optional field that restricts
+                                  the rule to only apply to traffic that originates
+                                  from (or terminates at) a pod running as a service
+                                  account whose name is in the list.
+                                items:
+                                  type: string
+                                type: array
+                              selector:
+                                description: Selector is an optional field that restricts
+                                  the rule to only apply to traffic that originates
+                                  from (or terminates at) a pod running as a service
+                                  account that matches the given label selector. If
+                                  both Names and Selector are specified then they are
+                                  AND'ed.
+                                type: string
+                            type: object
+                          services:
+                            description: "Services is an optional field that contains
+                            options for matching Kubernetes Services. If specified,
+                            only traffic that originates from or terminates at endpoints
+                            within the selected service(s) will be matched, and only
+                            to/from each endpoint's port. \n Services cannot be specified
+                            on the same rule as Selector, NotSelector, NamespaceSelector,
+                            Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                            Only valid on egress rules."
+                            properties:
+                              name:
+                                description: Name specifies the name of a Kubernetes
+                                  Service to match.
+                                type: string
+                              namespace:
+                                description: Namespace specifies the namespace of the
+                                  given Service. If left empty, the rule will match
+                                  within this policy's namespace.
+                                type: string
+                            type: object
+                        type: object
+                      http:
+                        description: HTTP contains match criteria that apply to HTTP
+                          requests.
+                        properties:
+                          methods:
+                            description: Methods is an optional field that restricts
+                              the rule to apply only to HTTP requests that use one of
+                              the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
+                              methods are OR'd together.
+                            items:
+                              type: string
+                            type: array
+                          paths:
+                            description: 'Paths is an optional field that restricts
+                            the rule to apply to HTTP requests that use one of the
+                            listed HTTP Paths. Multiple paths are OR''d together.
+                            e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
+                            ONLY specify either a `exact` or a `prefix` match. The
+                            validator will check for it.'
+                            items:
+                              description: 'HTTPPath specifies an HTTP path to match.
+                              It may be either of the form: exact: <path>: which matches
+                              the path exactly or prefix: <path-prefix>: which matches
+                              the path prefix'
+                              properties:
+                                exact:
+                                  type: string
+                                prefix:
+                                  type: string
+                              type: object
+                            type: array
+                        type: object
+                      icmp:
+                        description: ICMP is an optional field that restricts the rule
+                          to apply to a specific type and code of ICMP traffic.  This
+                          should only be specified if the Protocol field is set to "ICMP"
+                          or "ICMPv6".
+                        properties:
+                          code:
+                            description: Match on a specific ICMP code.  If specified,
+                              the Type value must also be specified. This is a technical
+                              limitation imposed by the kernel's iptables firewall,
+                              which Calico uses to enforce the rule.
+                            type: integer
+                          type:
+                            description: Match on a specific ICMP type.  For example
+                              a value of 8 refers to ICMP Echo Request (i.e. pings).
+                            type: integer
+                        type: object
+                      ipVersion:
+                        description: IPVersion is an optional field that restricts the
+                          rule to only match a specific IP version.
+                        type: integer
+                      metadata:
+                        description: Metadata contains additional information for this
+                          rule
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            description: Annotations is a set of key value pairs that
+                              give extra information about the rule
+                            type: object
+                        type: object
+                      notICMP:
+                        description: NotICMP is the negated version of the ICMP field.
+                        properties:
+                          code:
+                            description: Match on a specific ICMP code.  If specified,
+                              the Type value must also be specified. This is a technical
+                              limitation imposed by the kernel's iptables firewall,
+                              which Calico uses to enforce the rule.
+                            type: integer
+                          type:
+                            description: Match on a specific ICMP type.  For example
+                              a value of 8 refers to ICMP Echo Request (i.e. pings).
+                            type: integer
+                        type: object
+                      notProtocol:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        description: NotProtocol is the negated version of the Protocol
+                          field.
+                        pattern: ^.*
+                        x-kubernetes-int-or-string: true
+                      protocol:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        description: "Protocol is an optional field that restricts the
+                        rule to only apply to traffic of a specific IP protocol. Required
+                        if any of the EntityRules contain Ports (because ports only
+                        apply to certain protocols). \n Must be one of these string
+                        values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
+                        \"UDPLite\" or an integer in the range 1-255."
+                        pattern: ^.*
+                        x-kubernetes-int-or-string: true
+                      source:
+                        description: Source contains the match criteria that apply to
+                          source entity.
+                        properties:
+                          namespaceSelector:
+                            description: "NamespaceSelector is an optional field that
+                            contains a selector expression. Only traffic that originates
+                            from (or terminates at) endpoints within the selected
+                            namespaces will be matched. When both NamespaceSelector
+                            and another selector are defined on the same rule, then
+                            only workload endpoints that are matched by both selectors
+                            will be selected by the rule. \n For NetworkPolicy, an
+                            empty NamespaceSelector implies that the Selector is limited
+                            to selecting only workload endpoints in the same namespace
+                            as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                            NamespaceSelector implies that the Selector is limited
+                            to selecting only GlobalNetworkSet or HostEndpoint. \n
+                            For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                            the Selector applies to workload endpoints across all
+                            namespaces."
+                            type: string
+                          nets:
+                            description: Nets is an optional field that restricts the
+                              rule to only apply to traffic that originates from (or
+                              terminates at) IP addresses in any of the given subnets.
+                            items:
+                              type: string
+                            type: array
+                          notNets:
+                            description: NotNets is the negated version of the Nets
+                              field.
+                            items:
+                              type: string
+                            type: array
+                          notPorts:
+                            description: NotPorts is the negated version of the Ports
+                              field. Since only some protocols have ports, if any ports
+                              are specified it requires the Protocol match in the Rule
+                              to be set to "TCP" or "UDP".
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          notSelector:
+                            description: NotSelector is the negated version of the Selector
+                              field.  See Selector field for subtleties with negated
+                              selectors.
+                            type: string
+                          ports:
+                            description: "Ports is an optional field that restricts
+                            the rule to only apply to traffic that has a source (destination)
+                            port that matches one of these ranges/values. This value
+                            is a list of integers or strings that represent ranges
+                            of ports. \n Since only some protocols have ports, if
+                            any ports are specified it requires the Protocol match
+                            in the Rule to be set to \"TCP\" or \"UDP\"."
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          selector:
+                            description: "Selector is an optional field that contains
+                            a selector expression (see Policy for sample syntax).
+                            \ Only traffic that originates from (terminates at) endpoints
+                            matching the selector will be matched. \n Note that: in
+                            addition to the negated version of the Selector (see NotSelector
+                            below), the selector expression syntax itself supports
+                            negation.  The two types of negation are subtly different.
+                            One negates the set of matched endpoints, the other negates
+                            the whole match: \n \tSelector = \"!has(my_label)\" matches
+                            packets that are from other Calico-controlled \tendpoints
+                            that do not have the label \"my_label\". \n \tNotSelector
+                            = \"has(my_label)\" matches packets that are not from
+                            Calico-controlled \tendpoints that do have the label \"my_label\".
+                            \n The effect is that the latter will accept packets from
+                            non-Calico sources whereas the former is limited to packets
+                            from Calico-controlled endpoints."
+                            type: string
+                          serviceAccounts:
+                            description: ServiceAccounts is an optional field that restricts
+                              the rule to only apply to traffic that originates from
+                              (or terminates at) a pod running as a matching service
+                              account.
+                            properties:
+                              names:
+                                description: Names is an optional field that restricts
+                                  the rule to only apply to traffic that originates
+                                  from (or terminates at) a pod running as a service
+                                  account whose name is in the list.
+                                items:
+                                  type: string
+                                type: array
+                              selector:
+                                description: Selector is an optional field that restricts
+                                  the rule to only apply to traffic that originates
+                                  from (or terminates at) a pod running as a service
+                                  account that matches the given label selector. If
+                                  both Names and Selector are specified then they are
+                                  AND'ed.
+                                type: string
+                            type: object
+                          services:
+                            description: "Services is an optional field that contains
+                            options for matching Kubernetes Services. If specified,
+                            only traffic that originates from or terminates at endpoints
+                            within the selected service(s) will be matched, and only
+                            to/from each endpoint's port. \n Services cannot be specified
+                            on the same rule as Selector, NotSelector, NamespaceSelector,
+                            Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                            Only valid on egress rules."
+                            properties:
+                              name:
+                                description: Name specifies the name of a Kubernetes
+                                  Service to match.
+                                type: string
+                              namespace:
+                                description: Namespace specifies the namespace of the
+                                  given Service. If left empty, the rule will match
+                                  within this policy's namespace.
+                                type: string
+                            type: object
+                        type: object
+                    required:
+                      - action
+                    type: object
+                  type: array
+                ingress:
+                  description: The ordered set of ingress rules.  Each rule contains
+                    a set of packet match criteria and a corresponding action to apply.
+                  items:
+                    description: "A Rule encapsulates a set of match criteria and an
+                    action.  Both selector-based security Policy and security Profiles
+                    reference rules - separated out as a list of rules for both ingress
+                    and egress packet matching. \n Each positive match criteria has
+                    a negated version, prefixed with \"Not\". All the match criteria
+                    within a rule must be satisfied for a packet to match. A single
+                    rule can contain the positive and negative version of a match
+                    and both must be satisfied for the rule to match."
+                    properties:
+                      action:
+                        type: string
+                      destination:
+                        description: Destination contains the match criteria that apply
+                          to destination entity.
+                        properties:
+                          namespaceSelector:
+                            description: "NamespaceSelector is an optional field that
+                            contains a selector expression. Only traffic that originates
+                            from (or terminates at) endpoints within the selected
+                            namespaces will be matched. When both NamespaceSelector
+                            and another selector are defined on the same rule, then
+                            only workload endpoints that are matched by both selectors
+                            will be selected by the rule. \n For NetworkPolicy, an
+                            empty NamespaceSelector implies that the Selector is limited
+                            to selecting only workload endpoints in the same namespace
+                            as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                            NamespaceSelector implies that the Selector is limited
+                            to selecting only GlobalNetworkSet or HostEndpoint. \n
+                            For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                            the Selector applies to workload endpoints across all
+                            namespaces."
+                            type: string
+                          nets:
+                            description: Nets is an optional field that restricts the
+                              rule to only apply to traffic that originates from (or
+                              terminates at) IP addresses in any of the given subnets.
+                            items:
+                              type: string
+                            type: array
+                          notNets:
+                            description: NotNets is the negated version of the Nets
+                              field.
+                            items:
+                              type: string
+                            type: array
+                          notPorts:
+                            description: NotPorts is the negated version of the Ports
+                              field. Since only some protocols have ports, if any ports
+                              are specified it requires the Protocol match in the Rule
+                              to be set to "TCP" or "UDP".
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          notSelector:
+                            description: NotSelector is the negated version of the Selector
+                              field.  See Selector field for subtleties with negated
+                              selectors.
+                            type: string
+                          ports:
+                            description: "Ports is an optional field that restricts
+                            the rule to only apply to traffic that has a source (destination)
+                            port that matches one of these ranges/values. This value
+                            is a list of integers or strings that represent ranges
+                            of ports. \n Since only some protocols have ports, if
+                            any ports are specified it requires the Protocol match
+                            in the Rule to be set to \"TCP\" or \"UDP\"."
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          selector:
+                            description: "Selector is an optional field that contains
+                            a selector expression (see Policy for sample syntax).
+                            \ Only traffic that originates from (terminates at) endpoints
+                            matching the selector will be matched. \n Note that: in
+                            addition to the negated version of the Selector (see NotSelector
+                            below), the selector expression syntax itself supports
+                            negation.  The two types of negation are subtly different.
+                            One negates the set of matched endpoints, the other negates
+                            the whole match: \n \tSelector = \"!has(my_label)\" matches
+                            packets that are from other Calico-controlled \tendpoints
+                            that do not have the label \"my_label\". \n \tNotSelector
+                            = \"has(my_label)\" matches packets that are not from
+                            Calico-controlled \tendpoints that do have the label \"my_label\".
+                            \n The effect is that the latter will accept packets from
+                            non-Calico sources whereas the former is limited to packets
+                            from Calico-controlled endpoints."
+                            type: string
+                          serviceAccounts:
+                            description: ServiceAccounts is an optional field that restricts
+                              the rule to only apply to traffic that originates from
+                              (or terminates at) a pod running as a matching service
+                              account.
+                            properties:
+                              names:
+                                description: Names is an optional field that restricts
+                                  the rule to only apply to traffic that originates
+                                  from (or terminates at) a pod running as a service
+                                  account whose name is in the list.
+                                items:
+                                  type: string
+                                type: array
+                              selector:
+                                description: Selector is an optional field that restricts
+                                  the rule to only apply to traffic that originates
+                                  from (or terminates at) a pod running as a service
+                                  account that matches the given label selector. If
+                                  both Names and Selector are specified then they are
+                                  AND'ed.
+                                type: string
+                            type: object
+                          services:
+                            description: "Services is an optional field that contains
+                            options for matching Kubernetes Services. If specified,
+                            only traffic that originates from or terminates at endpoints
+                            within the selected service(s) will be matched, and only
+                            to/from each endpoint's port. \n Services cannot be specified
+                            on the same rule as Selector, NotSelector, NamespaceSelector,
+                            Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                            Only valid on egress rules."
+                            properties:
+                              name:
+                                description: Name specifies the name of a Kubernetes
+                                  Service to match.
+                                type: string
+                              namespace:
+                                description: Namespace specifies the namespace of the
+                                  given Service. If left empty, the rule will match
+                                  within this policy's namespace.
+                                type: string
+                            type: object
+                        type: object
+                      http:
+                        description: HTTP contains match criteria that apply to HTTP
+                          requests.
+                        properties:
+                          methods:
+                            description: Methods is an optional field that restricts
+                              the rule to apply only to HTTP requests that use one of
+                              the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
+                              methods are OR'd together.
+                            items:
+                              type: string
+                            type: array
+                          paths:
+                            description: 'Paths is an optional field that restricts
+                            the rule to apply to HTTP requests that use one of the
+                            listed HTTP Paths. Multiple paths are OR''d together.
+                            e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
+                            ONLY specify either a `exact` or a `prefix` match. The
+                            validator will check for it.'
+                            items:
+                              description: 'HTTPPath specifies an HTTP path to match.
+                              It may be either of the form: exact: <path>: which matches
+                              the path exactly or prefix: <path-prefix>: which matches
+                              the path prefix'
+                              properties:
+                                exact:
+                                  type: string
+                                prefix:
+                                  type: string
+                              type: object
+                            type: array
+                        type: object
+                      icmp:
+                        description: ICMP is an optional field that restricts the rule
+                          to apply to a specific type and code of ICMP traffic.  This
+                          should only be specified if the Protocol field is set to "ICMP"
+                          or "ICMPv6".
+                        properties:
+                          code:
+                            description: Match on a specific ICMP code.  If specified,
+                              the Type value must also be specified. This is a technical
+                              limitation imposed by the kernel's iptables firewall,
+                              which Calico uses to enforce the rule.
+                            type: integer
+                          type:
+                            description: Match on a specific ICMP type.  For example
+                              a value of 8 refers to ICMP Echo Request (i.e. pings).
+                            type: integer
+                        type: object
+                      ipVersion:
+                        description: IPVersion is an optional field that restricts the
+                          rule to only match a specific IP version.
+                        type: integer
+                      metadata:
+                        description: Metadata contains additional information for this
+                          rule
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            description: Annotations is a set of key value pairs that
+                              give extra information about the rule
+                            type: object
+                        type: object
+                      notICMP:
+                        description: NotICMP is the negated version of the ICMP field.
+                        properties:
+                          code:
+                            description: Match on a specific ICMP code.  If specified,
+                              the Type value must also be specified. This is a technical
+                              limitation imposed by the kernel's iptables firewall,
+                              which Calico uses to enforce the rule.
+                            type: integer
+                          type:
+                            description: Match on a specific ICMP type.  For example
+                              a value of 8 refers to ICMP Echo Request (i.e. pings).
+                            type: integer
+                        type: object
+                      notProtocol:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        description: NotProtocol is the negated version of the Protocol
+                          field.
+                        pattern: ^.*
+                        x-kubernetes-int-or-string: true
+                      protocol:
+                        anyOf:
+                          - type: integer
+                          - type: string
+                        description: "Protocol is an optional field that restricts the
+                        rule to only apply to traffic of a specific IP protocol. Required
+                        if any of the EntityRules contain Ports (because ports only
+                        apply to certain protocols). \n Must be one of these string
+                        values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
+                        \"UDPLite\" or an integer in the range 1-255."
+                        pattern: ^.*
+                        x-kubernetes-int-or-string: true
+                      source:
+                        description: Source contains the match criteria that apply to
+                          source entity.
+                        properties:
+                          namespaceSelector:
+                            description: "NamespaceSelector is an optional field that
+                            contains a selector expression. Only traffic that originates
+                            from (or terminates at) endpoints within the selected
+                            namespaces will be matched. When both NamespaceSelector
+                            and another selector are defined on the same rule, then
+                            only workload endpoints that are matched by both selectors
+                            will be selected by the rule. \n For NetworkPolicy, an
+                            empty NamespaceSelector implies that the Selector is limited
+                            to selecting only workload endpoints in the same namespace
+                            as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                            NamespaceSelector implies that the Selector is limited
+                            to selecting only GlobalNetworkSet or HostEndpoint. \n
+                            For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                            the Selector applies to workload endpoints across all
+                            namespaces."
+                            type: string
+                          nets:
+                            description: Nets is an optional field that restricts the
+                              rule to only apply to traffic that originates from (or
+                              terminates at) IP addresses in any of the given subnets.
+                            items:
+                              type: string
+                            type: array
+                          notNets:
+                            description: NotNets is the negated version of the Nets
+                              field.
+                            items:
+                              type: string
+                            type: array
+                          notPorts:
+                            description: NotPorts is the negated version of the Ports
+                              field. Since only some protocols have ports, if any ports
+                              are specified it requires the Protocol match in the Rule
+                              to be set to "TCP" or "UDP".
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          notSelector:
+                            description: NotSelector is the negated version of the Selector
+                              field.  See Selector field for subtleties with negated
+                              selectors.
+                            type: string
+                          ports:
+                            description: "Ports is an optional field that restricts
+                            the rule to only apply to traffic that has a source (destination)
+                            port that matches one of these ranges/values. This value
+                            is a list of integers or strings that represent ranges
+                            of ports. \n Since only some protocols have ports, if
+                            any ports are specified it requires the Protocol match
+                            in the Rule to be set to \"TCP\" or \"UDP\"."
+                            items:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^.*
+                              x-kubernetes-int-or-string: true
+                            type: array
+                          selector:
+                            description: "Selector is an optional field that contains
+                            a selector expression (see Policy for sample syntax).
+                            \ Only traffic that originates from (terminates at) endpoints
+                            matching the selector will be matched. \n Note that: in
+                            addition to the negated version of the Selector (see NotSelector
+                            below), the selector expression syntax itself supports
+                            negation.  The two types of negation are subtly different.
+                            One negates the set of matched endpoints, the other negates
+                            the whole match: \n \tSelector = \"!has(my_label)\" matches
+                            packets that are from other Calico-controlled \tendpoints
+                            that do not have the label \"my_label\". \n \tNotSelector
+                            = \"has(my_label)\" matches packets that are not from
+                            Calico-controlled \tendpoints that do have the label \"my_label\".
+                            \n The effect is that the latter will accept packets from
+                            non-Calico sources whereas the former is limited to packets
+                            from Calico-controlled endpoints."
+                            type: string
+                          serviceAccounts:
+                            description: ServiceAccounts is an optional field that restricts
+                              the rule to only apply to traffic that originates from
+                              (or terminates at) a pod running as a matching service
+                              account.
+                            properties:
+                              names:
+                                description: Names is an optional field that restricts
+                                  the rule to only apply to traffic that originates
+                                  from (or terminates at) a pod running as a service
+                                  account whose name is in the list.
+                                items:
+                                  type: string
+                                type: array
+                              selector:
+                                description: Selector is an optional field that restricts
+                                  the rule to only apply to traffic that originates
+                                  from (or terminates at) a pod running as a service
+                                  account that matches the given label selector. If
+                                  both Names and Selector are specified then they are
+                                  AND'ed.
+                                type: string
+                            type: object
+                          services:
+                            description: "Services is an optional field that contains
+                            options for matching Kubernetes Services. If specified,
+                            only traffic that originates from or terminates at endpoints
+                            within the selected service(s) will be matched, and only
+                            to/from each endpoint's port. \n Services cannot be specified
+                            on the same rule as Selector, NotSelector, NamespaceSelector,
+                            Ports, NotPorts, Nets, NotNets or ServiceAccounts. \n
+                            Only valid on egress rules."
+                            properties:
+                              name:
+                                description: Name specifies the name of a Kubernetes
+                                  Service to match.
+                                type: string
+                              namespace:
+                                description: Namespace specifies the namespace of the
+                                  given Service. If left empty, the rule will match
+                                  within this policy's namespace.
+                                type: string
+                            type: object
+                        type: object
+                    required:
+                      - action
+                    type: object
+                  type: array
+                order:
+                  description: Order is an optional field that specifies the order in
+                    which the policy is applied. Policies with higher "order" are applied
+                    after those with lower order.  If the order is omitted, it may be
+                    considered to be "infinite" - i.e. the policy will be applied last.  Policies
+                    with identical order will be applied in alphanumerical order based
+                    on the Policy "Name".
+                  type: number
+                selector:
+                  description: "The selector is an expression used to pick pick out
+                  the endpoints that the policy should be applied to. \n Selector
+                  expressions follow this syntax: \n \tlabel == \"string_literal\"
+                  \ ->  comparison, e.g. my_label == \"foo bar\" \tlabel != \"string_literal\"
+                  \  ->  not equal; also matches if label is not present \tlabel in
+                  { \"a\", \"b\", \"c\", ... }  ->  true if the value of label X is
+                  one of \"a\", \"b\", \"c\" \tlabel not in { \"a\", \"b\", \"c\",
+                  ... }  ->  true if the value of label X is not one of \"a\", \"b\",
+                  \"c\" \thas(label_name)  -> True if that label is present \t! expr
+                  -> negation of expr \texpr && expr  -> Short-circuit and \texpr
+                  || expr  -> Short-circuit or \t( expr ) -> parens for grouping \tall()
+                  or the empty selector -> matches all endpoints. \n Label names are
+                  allowed to contain alphanumerics, -, _ and /. String literals are
+                  more permissive but they do not support escape characters. \n Examples
+                  (with made-up labels): \n \ttype == \"webserver\" && deployment
+                  == \"prod\" \ttype in {\"frontend\", \"backend\"} \tdeployment !=
+                  \"dev\" \t! has(label_name)"
+                  type: string
+                serviceAccountSelector:
+                  description: ServiceAccountSelector is an optional field for an expression
+                    used to select a pod based on service accounts.
+                  type: string
+                types:
+                  description: "Types indicates whether this policy applies to ingress,
+                  or to egress, or to both.  When not explicitly specified (and so
+                  the value on creation is empty or nil), Calico defaults Types according
+                  to what Ingress and Egress are present in the policy.  The default
+                  is: \n - [ PolicyTypeIngress ], if there are no Egress rules (including
+                  the case where there are   also no Ingress rules) \n - [ PolicyTypeEgress
+                  ], if there are Egress rules but no Ingress rules \n - [ PolicyTypeIngress,
+                  PolicyTypeEgress ], if there are both Ingress and Egress rules.
+                  \n When the policy is read back again, Types will always be one
+                  of these values, never empty or nil."
+                  items:
+                    description: PolicyType enumerates the possible values of the PolicySpec
+                      Types field.
+                    type: string
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
 
 ---
 apiVersion: apiextensions.k8s.io/v1

--- a/yamls/rbac/rbac.yaml
+++ b/yamls/rbac/rbac.yaml
@@ -40,6 +40,7 @@ rules:
       - configmaps
       - services
       - endpoints
+      - serviceaccounts
     verbs:
       - create
       - get
@@ -83,6 +84,20 @@ rules:
       - "*"
     verbs:
       - "*"
+  - apiGroups:
+      - "crd.projectcalico.org"
+    resources:
+      - "*"
+    verbs:
+      - "*"
+  - apiGroups:
+      - "discovery.k8s.io"
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+      - watch
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/hybridnet/blob/main/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

Pull Request Description
---

### Describe what this PR does / why we need it
Introduce felix (v3.20.2) for NetworkPolicy.

### Does this pull request fix one issue?
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
NONE

### Describe how you did it
Reference to [terway](https://github.com/AliyunContainerService/terway/blob/73861e7b728226cde15fef5b257e7da2af7bf8ff/policy/felix/0001-terway.patch), and the biggest difference is changing the name of veth pair.

### Describe how to verify it
Apply the k8s e2e tests by `./sonobuoy  run --e2e-focus="\[Feature:NetworkPolicy\]" --e2e-skip="" --image-pull-policy IfNotPresent`.

### Special notes for reviews