### PR TITLE
controller: fix uninitialized nil map

### DIFF
--- a/pkg/controllers/multicluster/uuid_mutex.go
+++ b/pkg/controllers/multicluster/uuid_mutex.go
@@ -94,8 +94,9 @@ func (u *uuidMutex) GetUUIDs(name string) []types.UID {
 
 func NewUUIDMutex() UUIDMutex {
 	return &uuidMutex{
-		mutex:     sync.Mutex{},
-		idNameMap: make(map[types.UID]string),
+		mutex:           sync.Mutex{},
+		idNameMap:       make(map[types.UID]string),
+		nameLatestIDMap: make(map[string]types.UID),
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: Bruce Ma <brucema19901024@gmail.com>

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/hybridnet/blob/main/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

Pull Request Description
---

### Describe what this PR does / why we need it
Type `uuidMutex` has uninitialized map field, try to fix this bug.

### Does this pull request fix one issue?
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it

### Describe how to verify it

### Special notes for reviews