### PR TITLE
manager-runtime: refactor daemon run cause manager does not support restart

### DIFF
--- a/pkg/controllers/multicluster/remoteclusterstatus_checker.go
+++ b/pkg/controllers/multicluster/remoteclusterstatus_checker.go
@@ -160,7 +160,7 @@ func (r *RemoteClusterStatusChecker) checkClusterStatus(ctx context.Context, nam
 			}
 		}()
 
-		results, err := r.Checker.CheckAll(managerRuntime, clusterchecker.ClusterName(name))
+		results, err := r.Checker.CheckAll(managerRuntime.Manager(), clusterchecker.ClusterName(name))
 		if err != nil {
 			remoteCluster.Status.State = multiclusterv1.ClusterNotReady
 			fillCondition(&remoteCluster.Status, &metav1.Condition{

--- a/pkg/managerruntime/daemon.go
+++ b/pkg/managerruntime/daemon.go
@@ -16,25 +16,6 @@
 
 package managerruntime
 
-import (
-	"context"
-	"fmt"
-	"sync"
-	"time"
-
-	"github.com/go-logr/logr"
-	"k8s.io/apimachinery/pkg/util/wait"
-)
-
-type daemon struct {
-	mutex      sync.Mutex
-	logger     logr.Logger
-	startFunc  func(ctx context.Context) error
-	cancelFunc func()
-	ctx        context.Context
-	daemonStatus
-}
-
 type daemonStatus struct {
 	running            bool
 	restartCount       int32
@@ -51,60 +32,4 @@ func (s *daemonStatus) RestartCount() int32 {
 
 func (s *daemonStatus) TerminationMessage() string {
 	return s.terminationMessage
-}
-
-func (m *managerRuntime) Name() string {
-	return m.name
-}
-
-func (d *daemon) Run(ctx context.Context) error {
-	d.mutex.Lock()
-	defer d.mutex.Unlock()
-
-	if d.running {
-		return fmt.Errorf("runtime is running, can not run again")
-	}
-
-	d.ctx, d.cancelFunc = context.WithCancel(ctx)
-	d.running, d.restartCount, d.terminationMessage = true, 0, ""
-
-	go wait.UntilWithContext(d.ctx, func(ctx context.Context) {
-		d.logger.Info("starting daemon")
-		if err := d.startFunc(ctx); err != nil {
-			d.logger.Error(err, "daemon is exiting")
-			d.mutex.Lock()
-			d.restartCount++
-			d.terminationMessage = err.Error()
-			d.mutex.Unlock()
-		}
-	}, time.Second*30)
-
-	d.logger.Info("daemon is running")
-	return nil
-}
-
-func (d *daemon) Stop() error {
-	d.mutex.Lock()
-	defer d.mutex.Unlock()
-
-	if !d.running {
-		return nil
-	}
-
-	d.cancelFunc()
-	d.running, d.restartCount, d.terminationMessage = false, 0, ""
-
-	d.logger.Info("daemon is stopped")
-	return nil
-}
-
-func (d *daemon) Status() DaemonStatus {
-	d.mutex.Lock()
-	defer d.mutex.Unlock()
-
-	return &daemonStatus{
-		running:            d.running,
-		restartCount:       d.restartCount,
-		terminationMessage: d.terminationMessage,
-	}
 }

--- a/pkg/managerruntime/interface.go
+++ b/pkg/managerruntime/interface.go
@@ -24,9 +24,9 @@ import (
 )
 
 type ManagerRuntime interface {
-	manager.Manager
-	Daemon
 	Name() string
+	Manager() manager.Manager
+	Daemon
 }
 
 type Daemon interface {

--- a/pkg/managerruntime/manager_runtime.go
+++ b/pkg/managerruntime/manager_runtime.go
@@ -17,32 +17,145 @@
 package managerruntime
 
 import (
+	"context"
+	"fmt"
 	"sync"
+	"time"
 
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
+var _ ManagerRuntime = &managerRuntime{}
+
 type managerRuntime struct {
-	manager.Manager
-	name string
-	daemon
+	sync.RWMutex
+
+	name       string
+	logger     logr.Logger
+	restConfig *rest.Config
+	options    *manager.Options
+	initFunc   func(mgr manager.Manager) error
+
+	mgr manager.Manager
+
+	ctx        context.Context
+	cancelFunc func()
+
+	daemonStatus
 }
 
-func NewManagerRuntime(name string, config *rest.Config, options *manager.Options) (ManagerRuntime, error) {
-	manager, err := manager.New(config, *options)
+func (m *managerRuntime) Manager() manager.Manager {
+	m.RLock()
+	defer m.RUnlock()
+
+	return m.mgr
+}
+
+func (m *managerRuntime) Name() string {
+	return m.name
+}
+
+func (m *managerRuntime) Run(ctx context.Context) (err error) {
+	m.Lock()
+
+	if m.running {
+		return fmt.Errorf("runtime is running, can not run again")
+	}
+
+	m.ctx, m.cancelFunc = context.WithCancel(ctx)
+	m.running, m.restartCount, m.terminationMessage = true, 0, ""
+
+	m.Unlock()
+
+	go wait.UntilWithContext(m.ctx, func(ctx context.Context) {
+		m.Lock()
+
+		var err error
+		if m.mgr, err = manager.New(m.restConfig, *m.options); err != nil {
+			m.logger.Error(err, "unable to create manager")
+			m.restartCount++
+			m.terminationMessage = err.Error()
+			m.Unlock()
+			return
+		}
+
+		if err = m.initFunc(m.mgr); err != nil {
+			m.logger.Error(err, "unable to init manager")
+			m.restartCount++
+			m.terminationMessage = err.Error()
+			m.Unlock()
+			return
+		}
+
+		m.Unlock()
+
+		m.logger.Info("starting daemon")
+		if err = m.mgr.Start(ctx); err != nil {
+			m.logger.Error(err, "daemon is exiting")
+			m.Lock()
+			m.restartCount++
+			m.terminationMessage = err.Error()
+			m.Unlock()
+
+		}
+	}, time.Second*30)
+
+	m.logger.Info("running daemon")
+	return nil
+}
+
+func (m *managerRuntime) Stop() error {
+	m.Lock()
+	defer m.Unlock()
+
+	if !m.running {
+		return nil
+	}
+
+	m.cancelFunc()
+	m.running, m.restartCount, m.terminationMessage = false, 0, ""
+
+	m.logger.Info("stopping daemon")
+	return nil
+}
+
+func (m *managerRuntime) Status() DaemonStatus {
+	m.RLock()
+	defer m.RUnlock()
+
+	return &daemonStatus{
+		running:            m.running,
+		restartCount:       m.restartCount,
+		terminationMessage: m.terminationMessage,
+	}
+}
+
+func NewManagerRuntime(name string,
+	logger logr.Logger,
+	config *rest.Config,
+	options *manager.Options,
+	initFunc func(mgr manager.Manager) error) (ManagerRuntime, error) {
+
+	mgr, err := manager.New(config, *options)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unable to create manger: %v", err)
+	}
+
+	if err = initFunc(mgr); err != nil {
+		return nil, fmt.Errorf("unable to init manager: %v", err)
 	}
 
 	return &managerRuntime{
-		Manager: manager,
-		name:    name,
-		daemon: daemon{
-			mutex:        sync.Mutex{},
-			logger:       manager.GetLogger().WithName(name),
-			startFunc:    manager.Start,
-			daemonStatus: daemonStatus{},
-		},
+		RWMutex:      sync.RWMutex{},
+		name:         name,
+		logger:       logger.WithValues("name", name),
+		restConfig:   config,
+		options:      options,
+		initFunc:     initFunc,
+		mgr:          mgr,
+		daemonStatus: daemonStatus{},
 	}, nil
 }


### PR DESCRIPTION
Signed-off-by: Bruce Ma <brucema19901024@gmail.com>

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/hybridnet/blob/main/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

Pull Request Description
---

### Describe what this PR does / why we need it
`Manager` of controller-runtime does not support restarting for now, so if manager exits unexpectedly, daemon should not call `manager.Start` again and again.
Instead, in restart progress, another new manager should be constructed and initialized.

### Does this pull request fix one issue?
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it

### Describe how to verify it

### Special notes for reviews