### PR TITLE
chore: remove ldd check for CGO is disabled

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -53,10 +53,7 @@ RUN cd /go/src/github.com/projectcalico/felix && \
     -X github.com/projectcalico/felix/buildinfo.BuildDate=$(date -u +'%FT%T%z') \
     -X github.com/projectcalico/felix/buildinfo.GitRevision=${GIT_COMMIT} \
     -B 0x${GIT_COMMIT}" "github.com/projectcalico/felix/cmd/calico-felix" && \
-    ( ldd bin/calico-felix 2>&1 | grep -q -e "Not a valid dynamic program" \
-    -e "not a dynamic executable" || \
-    ( echo "Error: bin/calico-felix was not statically linked"; false ) ) \
-    && chmod +x /go/src/github.com/projectcalico/felix/bin/calico-felix
+    chmod +x /go/src/github.com/projectcalico/felix/bin/calico-felix
 
 FROM alpine:3.14
 

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -53,10 +53,7 @@ RUN cd /go/src/github.com/projectcalico/felix && \
     -X github.com/projectcalico/felix/buildinfo.BuildDate=$(date -u +'%FT%T%z') \
     -X github.com/projectcalico/felix/buildinfo.GitRevision=${GIT_COMMIT} \
     -B 0x${GIT_COMMIT}" "github.com/projectcalico/felix/cmd/calico-felix" && \
-    ( ldd bin/calico-felix 2>&1 | grep -q -e "Not a valid dynamic program" \
-    -e "not a dynamic executable" || \
-    ( echo "Error: bin/calico-felix was not statically linked"; false ) ) \
-    && chmod +x /go/src/github.com/projectcalico/felix/bin/calico-felix
+    chmod +x /go/src/github.com/projectcalico/felix/bin/calico-felix
 
 FROM arm64v8/alpine:3.14
 


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/hybridnet/blob/main/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

Pull Request Description
---

### Describe what this PR does / why we need it
Commands of `ldd` cannot run on the github actions' machine. Remove ldd check for CGO is disabled, the binary will always be statically linked.

### Does this pull request fix one issue?
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it

### Describe how to verify it

### Special notes for reviews