### PR TITLE
enable default-ip-family on dual-stack mode

### DIFF
--- a/pkg/ipam/types/constants.go
+++ b/pkg/ipam/types/constants.go
@@ -20,6 +20,8 @@ import (
 	"os"
 	"strings"
 	"sync"
+
+	"github.com/alibaba/hybridnet/pkg/feature"
 )
 
 type IPFamilyMode string
@@ -31,7 +33,15 @@ const (
 )
 
 func ParseIPFamilyFromString(in string) IPFamilyMode {
+	// if dual-stack not enabled, only ipv4 subnets will be
+	// recognized and promoted
+	if !feature.DualStackEnabled() {
+		return IPv4Only
+	}
+
 	switch strings.ToLower(in) {
+	case "":
+		return ParseIPFamilyFromEnvOnce()
 	case strings.ToLower(string(IPv4Only)):
 		return IPv4Only
 	case strings.ToLower(string(IPv6Only)):
@@ -40,6 +50,32 @@ func ParseIPFamilyFromString(in string) IPFamilyMode {
 		return DualStack
 	default:
 		return IPv4Only
+	}
+}
+
+var ipFamilyFromEnv IPFamilyMode
+var ipFamilyFromEnvOnce sync.Once
+
+func ParseIPFamilyFromEnvOnce() IPFamilyMode {
+	ipFamilyFromEnvOnce.Do(
+		func() {
+			ipFamilyFromEnv = ParseIPFamilyFromEnv()
+		},
+	)
+	return ipFamilyFromEnv
+}
+
+func ParseIPFamilyFromEnv() IPFamilyMode {
+	ipFamilyEnv := os.Getenv("DEFAULT_IP_FAMILY")
+	switch strings.ToLower(ipFamilyEnv) {
+	case strings.ToLower(string(IPv4Only)), "":
+		return IPv4Only
+	case strings.ToLower(string(IPv6Only)):
+		return IPv6Only
+	case strings.ToLower(string(DualStack)):
+		return DualStack
+	default:
+		return IPFamilyMode(ipFamilyEnv)
 	}
 }
 

--- a/pkg/webhook/validating/pod.go
+++ b/pkg/webhook/validating/pod.go
@@ -54,6 +54,10 @@ func PodCreateValidation(ctx context.Context, req *admission.Request, handler *H
 		return webhookutils.AdmissionErroredWithLog(http.StatusBadRequest, err, logger)
 	}
 
+	if pod.Spec.HostNetwork {
+		return admission.Allowed("skip validation on host-networking pod")
+	}
+
 	var (
 		networkTypeFromPod = utils.PickFirstNonEmptyString(pod.Annotations[constants.AnnotationNetworkType], pod.Labels[constants.LabelNetworkType])
 		networkType        = ipamtypes.ParseNetworkTypeFromString(networkTypeFromPod)


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/hybridnet/blob/main/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

Pull Request Description
---

### Describe what this PR does / why we need it
1. enable default-ip-family on dual-stack mode
2. only return IPv4Only if dualstack not enabled
3. skip webhook validation on host-networking pods

### Does this pull request fix one issue?
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it

### Describe how to verify it

### Special notes for reviews