### PR TITLE
fix address duplication error while active-standby switch happens

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -116,6 +116,9 @@ func main() {
 		}
 	}()
 
+	// Initialization should be after leader election success
+	<-mgr.Elected()
+
 	// wait for manager cache client ready
 	mgr.GetCache().WaitForCacheSync(globalContext)
 

--- a/pkg/controllers/networking/pod_controller.go
+++ b/pkg/controllers/networking/pod_controller.go
@@ -129,6 +129,11 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result
 			(len(ipInstanceList) == 2 && ipFamily == ipamtypes.DualStack) {
 			return ctrl.Result{}, nil
 		}
+
+		if len(ipInstanceList) > 0 {
+			return ctrl.Result{}, fmt.Errorf("duplicated ip instances exist for pod: %v/%v, pod ip family is %v",
+				pod.Namespace, pod.Name, ipFamily)
+		}
 	}
 
 	networkName, err = r.selectNetwork(ctx, pod)

--- a/pkg/controllers/networking/pod_ip_cache.go
+++ b/pkg/controllers/networking/pod_ip_cache.go
@@ -99,6 +99,9 @@ func NewPodIPCache(ctx context.Context, c client.Reader, logger logr.Logger) (Po
 				recordedIPInstances = cache.podToIP[namespacedKey(podName, ip.Namespace)].ipInstanceNames
 			}
 
+			logger.V(1).Info("add record to init cache", "ip",
+				ip.Name, "namespace", ip.Namespace, "pod", podName, "pod uid", podUID)
+
 			// this is different from a normal Record action
 			cache.podToIP[namespacedKey(podName, ip.Namespace)] = &podAllocatedInfo{
 				podUID:          podUID,


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/hybridnet/blob/main/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

Pull Request Description
---

### Describe what this PR does / why we need it
If active-standby switch of manager happens, will cause address duplication error, because initialization of pod ip cache is  before leader election.

### Does this pull request fix one issue?
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it

### Describe how to verify it

### Special notes for reviews