### PR TITLE
disable the automatic iptables mode detection of felix

### DIFF
--- a/policy/felix/0002-disable-iptables-mode-detection.patch
+++ b/policy/felix/0002-disable-iptables-mode-detection.patch
@@ -1,0 +1,85 @@
+From 46fc36063ac49c1d79b276e0952ce0314f752937 Mon Sep 17 00:00:00 2001
+From: hhyasdf <552483776@qq.com>
+Date: Tue, 28 Jun 2022 15:31:09 +0800
+Subject: [PATCH 2/2] disable iptables mode detection
+
+---
+ dataplane/linux/int_dataplane.go |  4 ++--
+ iptables/feature_detect.go       |  2 +-
+ iptables/table.go                | 24 ++++++++++++++----------
+ 3 files changed, 17 insertions(+), 13 deletions(-)
+
+diff --git a/dataplane/linux/int_dataplane.go b/dataplane/linux/int_dataplane.go
+index a09d235a..f5503efd 100644
+--- a/dataplane/linux/int_dataplane.go
++++ b/dataplane/linux/int_dataplane.go
+@@ -335,7 +335,7 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
+ 	dp.ifaceMonitor.StateCallback = dp.onIfaceStateChange
+ 	dp.ifaceMonitor.AddrCallback = dp.onIfaceAddrsChange
+ 
+-	backendMode := iptables.DetectBackend(config.LookPathOverride, iptables.NewRealCmd, config.IptablesBackend)
++	//backendMode := iptables.DetectBackend(config.LookPathOverride, iptables.NewRealCmd, config.IptablesBackend)
+ 
+ 	// Most iptables tables need the same options.
+ 	iptablesOptions := iptables.TableOptions{
+@@ -345,7 +345,7 @@ func NewIntDataplaneDriver(config Config) *InternalDataplane {
+ 		PostWriteInterval:     config.IptablesPostWriteCheckInterval,
+ 		LockTimeout:           config.IptablesLockTimeout,
+ 		LockProbeInterval:     config.IptablesLockProbeInterval,
+-		BackendMode:           backendMode,
++		//BackendMode:           backendMode,
+ 		LookPathOverride:      config.LookPathOverride,
+ 		OnStillAlive:          dp.reportHealth,
+ 		OpRecorder:            dp.loopSummarizer,
+diff --git a/iptables/feature_detect.go b/iptables/feature_detect.go
+index 603baad7..4f264cd3 100644
+--- a/iptables/feature_detect.go
++++ b/iptables/feature_detect.go
+@@ -269,7 +269,7 @@ func findBestBinary(lookPath func(file string) (string, error), ipVersion uint8,
+ 		verInfix = "6"
+ 	}
+ 	candidates := []string{
+-		"ip" + verInfix + "tables-" + backendMode + "-" + saveOrRestore,
++		//"ip" + verInfix + "tables-" + backendMode + "-" + saveOrRestore,
+ 		"ip" + verInfix + "tables-" + saveOrRestore,
+ 	}
+ 
+diff --git a/iptables/table.go b/iptables/table.go
+index 064d1dec..8a1d492a 100644
+--- a/iptables/table.go
++++ b/iptables/table.go
+@@ -439,17 +439,21 @@ func NewTable(
+ 		table.onStillAlive = func() {}
+ 	}
+ 
+-	iptablesVariant := strings.ToLower(options.BackendMode)
+-	if iptablesVariant == "" {
+-		iptablesVariant = "legacy"
+-	}
+-	if iptablesVariant == "nft" {
+-		log.Info("Enabling iptables-in-nftables-mode workarounds.")
+-		table.nftablesMode = true
+-	}
++	//iptablesVariant := strings.ToLower(options.BackendMode)
++	//if iptablesVariant == "" {
++	//	iptablesVariant = "legacy"
++	//}
++	//if iptablesVariant == "nft" {
++	//	log.Info("Enabling iptables-in-nftables-mode workarounds.")
++	//	table.nftablesMode = true
++	//}
++	//
++	//table.iptablesRestoreCmd = findBestBinary(table.lookPath, ipVersion, iptablesVariant, "restore")
++	//table.iptablesSaveCmd = findBestBinary(table.lookPath, ipVersion, iptablesVariant, "save")
+ 
+-	table.iptablesRestoreCmd = findBestBinary(table.lookPath, ipVersion, iptablesVariant, "restore")
+-	table.iptablesSaveCmd = findBestBinary(table.lookPath, ipVersion, iptablesVariant, "save")
++	// do not use iptables-legacy/nft-xxx commands in hybridnet
++	table.iptablesRestoreCmd = findBestBinary(table.lookPath, ipVersion, "", "restore")
++	table.iptablesSaveCmd = findBestBinary(table.lookPath, ipVersion, "", "save")
+ 
+ 	return table
+ }
+-- 
+2.30.1 (Apple Git-130)
+


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/hybridnet/blob/main/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

Pull Request Description
---

### Describe what this PR does / why we need it
Felix will use the automatic iptables mode detection of itself to use "iptables-nft-save/restore" or "iptables-legacy-save/restore", which is not stable enough. This pr remove the automatic iptables mode detection of felix and use [iptables-wrapper-installer.sh](https://github.com/alibaba/hybridnet/blob/main/dist/images/iptables-wrapper-installer.sh) to delete iptables mode of host.

### Does this pull request fix one issue?
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it

### Describe how to verify it

### Special notes for reviews