### PR TITLE
fix bug on lastAllocatedSubnets in network status

### DIFF
--- a/pkg/ipam/manager/manager.go
+++ b/pkg/ipam/manager/manager.go
@@ -124,7 +124,7 @@ func (m *Manager) GetSubnetUsage(networkName, subnetName string) (*types.Usage, 
 	}
 
 	var subnet *types.Subnet
-	if subnet, err = network.GetSubnet(subnetName); err != nil {
+	if subnet, err = network.GetSubnetByName(subnetName); err != nil {
 		return nil, fmt.Errorf("fail to get subnet %s: %v", subnetName, err)
 	}
 
@@ -180,7 +180,7 @@ func (m *Manager) allocateIPv4(networkName string, podInfo types.PodInfo, option
 	}
 
 	var subnet *types.Subnet
-	if subnet, err = network.GetIPv4Subnet(specifiedSubnetName); err != nil {
+	if subnet, err = network.GetIPv4SubnetByNameOrAvailable(specifiedSubnetName); err != nil {
 		return nil, fmt.Errorf("fail to get ipv4 subnet: %v", err)
 	}
 
@@ -211,7 +211,7 @@ func (m *Manager) allocateIPv6(networkName string, podInfo types.PodInfo, option
 	}
 
 	var subnet *types.Subnet
-	if subnet, err = network.GetIPv6Subnet(specifiedSubnetName); err != nil {
+	if subnet, err = network.GetIPv6SubnetByNameOrAvailable(specifiedSubnetName); err != nil {
 		return nil, fmt.Errorf("fail to get ipv6 subnet: %v", err)
 	}
 
@@ -242,7 +242,7 @@ func (m *Manager) allocateDualStack(networkName string, podInfo types.PodInfo, o
 	}
 
 	var ipv4Subnet, ipv6Subnet *types.Subnet
-	if ipv4Subnet, ipv6Subnet, err = network.GetDualStackSubnets(specifiedIPv4SubnetName, specifiedIPv6SubnetName); err != nil {
+	if ipv4Subnet, ipv6Subnet, err = network.GetDualStackSubnetsByNameOrAvailable(specifiedIPv4SubnetName, specifiedIPv6SubnetName); err != nil {
 		return nil, fmt.Errorf("fail to get paired subnets: %v", err)
 	}
 
@@ -411,7 +411,7 @@ func (m *Manager) Release(networkName string, releaseSuites []types.SubnetIPSuit
 		}
 
 		var subnet *types.Subnet
-		if subnet, err = network.GetSubnet(releaseSuite.Subnet); err != nil {
+		if subnet, err = network.GetSubnetByName(releaseSuite.Subnet); err != nil {
 			return fmt.Errorf("fail to get subnet %s: %v", releaseSuite.Subnet, err)
 		}
 
@@ -444,7 +444,7 @@ func (m *Manager) Reserve(networkName string, reserveSuites []types.SubnetIPSuit
 		}
 
 		var subnet *types.Subnet
-		if subnet, err = network.GetSubnet(reserveSuite.Subnet); err != nil {
+		if subnet, err = network.GetSubnetByName(reserveSuite.Subnet); err != nil {
 			return fmt.Errorf("fail to get subnet %s: %v", reserveSuite.Subnet, err)
 		}
 

--- a/pkg/ipam/types/types.go
+++ b/pkg/ipam/types/types.go
@@ -25,10 +25,11 @@ const (
 
 type Network struct {
 	// Spec fields
-	Name                string
-	NetID               *uint32
-	LastAllocatedSubnet string
-	Type                NetworkType
+	Name                    string
+	NetID                   *uint32
+	LastAllocatedSubnet     string
+	LastAllocatedIPv6Subnet string
+	Type                    NetworkType
 
 	Subnets *SubnetSlice
 }

--- a/pkg/ipam/types/usage.go
+++ b/pkg/ipam/types/usage.go
@@ -37,9 +37,8 @@ func (u *Usage) Add(in *Usage) {
 }
 
 type NetworkUsage struct {
-	LastAllocation string
-	Usages         map[IPFamilyMode]*Usage
-	SubnetUsages   map[string]*Usage
+	Usages       map[IPFamilyMode]*Usage
+	SubnetUsages map[string]*Usage
 }
 
 func (n *NetworkUsage) GetByType(ipFamily IPFamilyMode) *Usage {

--- a/pkg/utils/transform/ipam.go
+++ b/pkg/utils/transform/ipam.go
@@ -46,6 +46,7 @@ func TransferNetworkForIPAM(in *v1.Network) *ipamtypes.Network {
 	return ipamtypes.NewNetwork(in.Name,
 		int32pToUint32p(in.Spec.NetID),
 		in.Status.LastAllocatedSubnet,
+		in.Status.LastAllocatedIPv6Subnet,
 		ipamtypes.ParseNetworkTypeFromString(string(v1.GetNetworkType(in))),
 	)
 }


### PR DESCRIPTION
Signed-off-by: Bruce Ma <brucema19901024@gmail.com>

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/hybridnet/blob/main/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

Pull Request Description
---

### Describe what this PR does / why we need it
fix bug on lastAllocatedSubnets in network status

1. record last allocated subnets in network object, by counting
   get-availalbe subnets methods
2. rename some misunderstanding function names
2. in the furture, the IPAM manger should separate the allocation of
   IPv4 and IPv6, also record last allocated subnet by IP allocation


### Does this pull request fix one issue?
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it

### Describe how to verify it

### Special notes for reviews