### PR TITLE
Support specify mac pool for stateful workloads

### DIFF
--- a/pkg/constants/annotations.go
+++ b/pkg/constants/annotations.go
@@ -20,6 +20,8 @@ const (
 	AnnotationIPPool   = "networking.alibaba.com/ip-pool"
 	AnnotationIPFamily = "networking.alibaba.com/ip-family"
 
+	AnnotationMACPool = "networking.alibaba.com/mac-pool"
+
 	AnnotationIPRetain = "networking.alibaba.com/ip-retain"
 
 	AnnotationSpecifiedNetwork = "networking.alibaba.com/specified-network"

--- a/pkg/controllers/networking/utils.go
+++ b/pkg/controllers/networking/utils.go
@@ -23,6 +23,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	networkingv1 "github.com/alibaba/hybridnet/pkg/apis/networking/v1"
+	ipamtypes "github.com/alibaba/hybridnet/pkg/ipam/types"
 	globalutils "github.com/alibaba/hybridnet/pkg/utils"
 )
 
@@ -45,6 +46,18 @@ func InitIndexers(mgr ctrl.Manager) (err error) {
 			default:
 				return nil
 			}
+		}); err != nil {
+		return err
+	}
+
+	// init mac indexer for IPInstances
+	if err = mgr.GetFieldIndexer().IndexField(context.TODO(), &networkingv1.IPInstance{},
+		ipamtypes.IndexerFieldMAC, func(obj client.Object) []string {
+			ipInstance, ok := obj.(*networkingv1.IPInstance)
+			if !ok {
+				return nil
+			}
+			return []string{ipInstance.Spec.Address.MAC}
 		}); err != nil {
 		return err
 	}

--- a/pkg/controllers/networking/utils.go
+++ b/pkg/controllers/networking/utils.go
@@ -23,7 +23,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	networkingv1 "github.com/alibaba/hybridnet/pkg/apis/networking/v1"
-	ipamtypes "github.com/alibaba/hybridnet/pkg/ipam/types"
 	globalutils "github.com/alibaba/hybridnet/pkg/utils"
 )
 
@@ -52,7 +51,7 @@ func InitIndexers(mgr ctrl.Manager) (err error) {
 
 	// init mac indexer for IPInstances
 	if err = mgr.GetFieldIndexer().IndexField(context.TODO(), &networkingv1.IPInstance{},
-		ipamtypes.IndexerFieldMAC, func(obj client.Object) []string {
+		IndexerFieldMAC, func(obj client.Object) []string {
 			ipInstance, ok := obj.(*networkingv1.IPInstance)
 			if !ok {
 				return nil

--- a/pkg/ipam/store/store.go
+++ b/pkg/ipam/store/store.go
@@ -206,14 +206,6 @@ func (s *crdStore) IPUnBind(ctx context.Context, namespace, ip string) (err erro
 
 // createIPInstance will create an IPInstance by pod info, ip info and mac address
 func (s *crdStore) createIPInstance(ctx context.Context, pod *corev1.Pod, ip *ipamtypes.IP, macAddr string, ownerReference *metav1.OwnerReference, additionalLabels map[string]string) (ipIns *networkingv1.IPInstance, err error) {
-	// Check MAC address collision with existing ip instances of other pods.
-	if len(macAddr) > 0 {
-		err = s.checkMACAddressCollision(pod, macAddr)
-		if err != nil {
-			return nil, fmt.Errorf("fail to check MAC address collision %v", err)
-		}
-	}
-
 	ipInstance := &networkingv1.IPInstance{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      utils.ToDNSLabelFormatName(ip),
@@ -228,14 +220,6 @@ func (s *crdStore) createIPInstance(ctx context.Context, pod *corev1.Pod, ip *ip
 
 // createOrUpdateIPInstance will create or update an IPInstance by pod info, ip info and mac address
 func (s *crdStore) createOrUpdateIPInstance(ctx context.Context, pod *corev1.Pod, ip *ipamtypes.IP, macAddr string, ownerReference *metav1.OwnerReference, additionalLabels map[string]string) (ipIns *networkingv1.IPInstance, err error) {
-	// Check MAC address collision with existing ip instances of other pods.
-	if len(macAddr) > 0 {
-		err = s.checkMACAddressCollision(pod, macAddr)
-		if err != nil {
-			return nil, fmt.Errorf("fail to check MAC address collision %v", err)
-		}
-	}
-
 	var ipInstance = &networkingv1.IPInstance{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      utils.ToDNSLabelFormatName(ip),
@@ -254,22 +238,6 @@ func (s *crdStore) createOrUpdateIPInstance(ctx context.Context, pod *corev1.Pod
 	})
 
 	return ipInstance, err
-}
-
-func (s *crdStore) checkMACAddressCollision(pod *corev1.Pod, macAddr string) (err error) {
-	ipInstanceList := &networkingv1.IPInstanceList{}
-	if err = s.List(context.TODO(), ipInstanceList, client.MatchingFields{ipamtypes.IndexerFieldMAC: macAddr}); err != nil {
-		return fmt.Errorf("unable to list ip instances by indexer MAC %s: %v", macAddr, err)
-	}
-	for _, ipInstance := range ipInstanceList.Items {
-		if !ipInstance.DeletionTimestamp.IsZero() {
-			continue
-		}
-		if ipInstance.Status.PodNamespace != pod.GetNamespace() || ipInstance.Status.PodName != pod.GetName() {
-			return fmt.Errorf("specified mac address %s is in conflict with existing ip instance %s/%s", macAddr, ipInstance.Namespace, ipInstance.Name)
-		}
-	}
-	return nil
 }
 
 // deleteIPInstance will remove an IPInstance by namespace and name

--- a/pkg/ipam/types/constants.go
+++ b/pkg/ipam/types/constants.go
@@ -22,6 +22,10 @@ import (
 	"sync"
 )
 
+const (
+	IndexerFieldMAC = "mac"
+)
+
 type IPFamilyMode string
 
 const (

--- a/pkg/ipam/types/constants.go
+++ b/pkg/ipam/types/constants.go
@@ -22,10 +22,6 @@ import (
 	"sync"
 )
 
-const (
-	IndexerFieldMAC = "mac"
-)
-
 type IPFamilyMode string
 
 const (

--- a/pkg/ipam/types/options.go
+++ b/pkg/ipam/types/options.go
@@ -104,6 +104,9 @@ type CoupleOptions struct {
 	// AdditionalLabels will be patched to IP when coupling
 	AdditionalLabels map[string]string
 
+	// SpecifiedMACAddress will be used as mac address of Pod
+	SpecifiedMACAddress SpecifiedMACAddress
+
 	// OwnerReference will replace the owner reference fetched from Pod explicitly
 	OwnerReference *metav1.OwnerReference
 }
@@ -122,6 +125,9 @@ type ReCoupleOption interface {
 type ReCoupleOptions struct {
 	// AdditionalLabels will be patched to IP when recoupling
 	AdditionalLabels map[string]string
+
+	// SpecifiedMACAddress will be used as mac address of Pod
+	SpecifiedMACAddress SpecifiedMACAddress
 
 	// OwnerReference will replace the owner reference fetched from Pod explicitly
 	OwnerReference *metav1.OwnerReference
@@ -190,4 +196,24 @@ type DropPodName bool
 
 func (d DropPodName) ApplyToReserve(options *ReserveOptions) {
 	options.DropPodName = bool(d)
+}
+
+type SpecifiedMACAddress string
+
+func (s SpecifiedMACAddress) ApplyToReCouple(options *ReCoupleOptions) {
+	options.SpecifiedMACAddress = s
+}
+
+func (s SpecifiedMACAddress) ApplyToCouple(options *CoupleOptions) {
+	options.SpecifiedMACAddress = s
+}
+
+func (s SpecifiedMACAddress) IsEmpty() bool {
+	return len(s) == 0
+}
+
+// EqualsTo returns whether current specified MAC address is equal to another
+// normalized MAC address.
+func (s SpecifiedMACAddress) EqualsTo(normalizedMACAddr string) bool {
+	return string(s) == normalizedMACAddr
 }

--- a/pkg/utils/mac/format.go
+++ b/pkg/utils/mac/format.go
@@ -1,0 +1,28 @@
+/*
+ Copyright 2022 The Hybridnet Authors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package mac
+
+import "net"
+
+// NormalizeMAC returns a well formatted hardware address string if mac is valid, or an empty string if not.
+func NormalizeMAC(mac string) string {
+	hw, err := net.ParseMAC(mac)
+	if err != nil {
+		return ""
+	}
+	return hw.String()
+}

--- a/pkg/utils/mac/format_test.go
+++ b/pkg/utils/mac/format_test.go
@@ -1,0 +1,60 @@
+/*
+ Copyright 2022 The Hybridnet Authors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package mac
+
+import "testing"
+
+func TestNormalizeMAC(t *testing.T) {
+	tests := []struct {
+		mac   string
+		valid bool
+	}{
+		{
+			"1.2.3.4",
+			false,
+		},
+		{
+			"",
+			false,
+		},
+		{
+			"11.22.33.44.55",
+			false,
+		},
+		{
+			"00:00:00:00",
+			false,
+		},
+		{
+			"00-16-EA-AE-3C-40",
+			true,
+		},
+		{
+			"08:00:20:0A:8C:6D",
+			true,
+		},
+	}
+	for _, test := range tests {
+		normalizedMac := NormalizeMAC(test.mac)
+		if len(normalizedMac) > 0 && test.valid {
+			t.Logf("%s is normalized to %s", test.mac, normalizedMac)
+		}
+		if (len(normalizedMac) > 0) != test.valid {
+			t.Errorf("fail to normalize mac %s", test.mac)
+		}
+	}
+}


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/hybridnet/blob/main/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

Pull Request Description
---

### Describe what this PR does / why we need it
Support specify MAC address pool via pod annotation for stateful workloads.

### Does this pull request fix one issue?
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
Fixes #190 

### Describe how you did it
1. Verify the validness of specified MAC addresses in validating webhook;
2. Introduce `SpecifiedMACAddress` as one of the couple/recouple options;
3. Check whether the specified MAC address is in conflict with existing IP instances.

### Describe how to verify it
Similar to ip pool assignment which is described in [wiki docs](https://github.com/alibaba/hybridnet/wiki/Static-pod-ip-addresses-for-StatefulSet). Just specify MAC addresses via annotation `networking.alibaba.com/mac-pool` on stateful workload pod templates, and separate them by comma.

### Special notes for reviews