### PR TITLE
adapt to kube proxy nodeport

### DIFF
--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -19,25 +19,25 @@ package main
 import (
 	"os"
 
-	multiclusterv1 "github.com/alibaba/hybridnet/pkg/apis/multicluster/v1"
+	zapinit "github.com/alibaba/hybridnet/pkg/zap"
 
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	"github.com/alibaba/hybridnet/pkg/feature"
-
+	multiclusterv1 "github.com/alibaba/hybridnet/pkg/apis/multicluster/v1"
 	networkingv1 "github.com/alibaba/hybridnet/pkg/apis/networking/v1"
 	daemonconfig "github.com/alibaba/hybridnet/pkg/daemon/config"
 	"github.com/alibaba/hybridnet/pkg/daemon/controller"
 	"github.com/alibaba/hybridnet/pkg/daemon/server"
+	"github.com/alibaba/hybridnet/pkg/feature"
 )
 
 var gitCommit string
 
 func main() {
-	log.SetLogger(zap.New(zap.UseDevMode(true)))
+	log.SetLogger(zapinit.NewZapLogger())
 
 	var entryLog = log.Log.WithName("entry")
 	entryLog.Info("starting hybridnet daemon",

--- a/pkg/daemon/route/compatible.go
+++ b/pkg/daemon/route/compatible.go
@@ -1,0 +1,85 @@
+/*
+ Copyright 2021 The Hybridnet Authors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package route
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/alibaba/hybridnet/pkg/constants"
+	"github.com/vishvananda/netlink"
+)
+
+func checkIsOldFromPodSubnetRule(rule netlink.Rule, family int) (bool, error) {
+	if rule.IifName != "" || rule.OifName != "" || rule.Dst != nil || rule.Src == nil ||
+		rule.Table < MinRouteTableNum || rule.Table >= MaxRouteTableNum {
+		return false, nil
+	}
+
+	routes, err := listRoutesByTable(rule.Table, family)
+	if err != nil {
+		return false, fmt.Errorf("failed to list route for table %v: %v", rule.Table, err)
+	}
+
+	for _, route := range routes {
+		// skip exclude routes
+		if isExcludeRoute(&route) {
+			continue
+		}
+
+		link, err := netlink.LinkByIndex(route.LinkIndex)
+		if err != nil {
+			return false, fmt.Errorf("failed to get link for route %v: %v", route.String(), err)
+		}
+
+		// Underlay subnet route table found.
+		// For a vlan route table, only one default route and one subnet route will exist.
+		// For a bgp route table, only one default route will exist.
+		if route.Dst == nil && len(routes) == 2 || len(routes) == 1 {
+			return true, nil
+		}
+
+		// overlay subnet route table found
+		if strings.Contains(link.Attrs().Name, constants.VxlanLinkInfix) &&
+			!(route.Dst != nil && !route.Dst.IP.IsGlobalUnicast()) {
+			return true, nil
+		}
+
+	}
+
+	return false, nil
+}
+
+func updateOldFromPodSubnetRuleToNew(rule netlink.Rule) error {
+	newRule := netlink.NewRule()
+
+	newRule.Src = rule.Src
+	newRule.Priority = rule.Priority
+	newRule.Table = rule.Table
+	newRule.Mark = fromRuleMark
+	newRule.Mask = fromRuleMask
+
+	if err := netlink.RuleAdd(newRule); err != nil {
+		return fmt.Errorf("failed to add new rule %v: %v", newRule.String(), err)
+	}
+
+	if err := netlink.RuleDel(&rule); err != nil {
+		return fmt.Errorf("failed to delete old rule %v: %v", rule.String(), err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/hybridnet/blob/main/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

Pull Request Description
---

### Describe what this PR does / why we need it
Make the full-NATed traffic (including nodeport svc) of kube-proxy be ignored by "from" policy routing rules of hybridnet while doing the route decision.

Because the full-NATed traffic is always supposed to be "Node" traffic.

### Does this pull request fix one issue?
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
Fix #297 

### Describe how you did it
1. Use `conntrack` module of iptables to mark full-NATed traffic
2. Use `ip rule fwmark` to ignore marked traffic by hybridnet and kube-proxy

### Describe how to verify it

### Special notes for reviews