### PR TITLE
unexpected pods could be handled in controller if webhook inactive

### DIFF
--- a/charts/hybridnet/templates/webhookconfigurations.yaml
+++ b/charts/hybridnet/templates/webhookconfigurations.yaml
@@ -33,7 +33,7 @@ webhooks:
         namespace: kube-system
         port: 443
         path: "/validate"
-    failurePolicy: Fail
+    failurePolicy: Ignore
     matchPolicy: Equivalent
     name: core-v1.validating.hybridnet
     objectSelector:
@@ -64,7 +64,7 @@ webhooks:
         namespace: kube-system
         port: 443
         path: "/mutate"
-    failurePolicy: Fail
+    failurePolicy: Ignore
     matchPolicy: Equivalent
     name: core-v1.mutating.hybridnet
     objectSelector:

--- a/pkg/constants/annotations.go
+++ b/pkg/constants/annotations.go
@@ -34,4 +34,6 @@ const (
 	AnnotationNodeVtepIP           = "networking.alibaba.com/vtep-ip"
 	AnnotationNodeVtepMac          = "networking.alibaba.com/vtep-mac"
 	AnnotationNodeLocalVxlanIPList = "networking.alibaba.com/local-vxlan-ip-list"
+
+	AnnotationHandledByWebhook = "networking.alibaba.com/handled-by-webhook"
 )

--- a/pkg/controllers/utils/client.go
+++ b/pkg/controllers/utils/client.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -282,4 +283,12 @@ func GetClusterUUID(ctx context.Context, c client.Reader) (types.UID, error) {
 		return "", err
 	}
 	return namespace.UID, nil
+}
+
+func CheckObjectExistence(ctx context.Context, c client.Reader, namespacedName types.NamespacedName, obj client.Object) (bool, error) {
+	err := c.Get(ctx, namespacedName, obj)
+	if errors.IsNotFound(err) {
+		return false, nil
+	}
+	return err == nil, err
 }

--- a/pkg/controllers/utils/format.go
+++ b/pkg/controllers/utils/format.go
@@ -23,8 +23,6 @@ import (
 	"strings"
 
 	"github.com/alibaba/hybridnet/pkg/utils"
-
-	"github.com/alibaba/hybridnet/pkg/ipam/types"
 )
 
 var (
@@ -37,21 +35,6 @@ func ToIPFormat(name string) string {
 		return net.ParseIP(strings.ReplaceAll(name, "-", ":")).String()
 	}
 	return strings.ReplaceAll(name, "-", ".")
-}
-
-func ToIPFormatWithFamily(name string) (string, bool) {
-	const IPv6SeparatorCount = 7
-	if isIPv6 := strings.Count(name, "-") == IPv6SeparatorCount; isIPv6 {
-		return net.ParseIP(strings.ReplaceAll(name, "-", ":")).String(), true
-	}
-	return strings.ReplaceAll(name, "-", "."), false
-}
-
-func ToIPFamilyMode(isIPv6 bool) types.IPFamilyMode {
-	if isIPv6 {
-		return types.IPv6
-	}
-	return types.IPv4
 }
 
 func GetIndexFromName(name string) int {

--- a/pkg/controllers/utils/pod.go
+++ b/pkg/controllers/utils/pod.go
@@ -16,7 +16,11 @@
 
 package utils
 
-import v1 "k8s.io/api/core/v1"
+import (
+	v1 "k8s.io/api/core/v1"
+
+	"github.com/alibaba/hybridnet/pkg/webhook/utils"
+)
 
 func PodIsEvicted(pod *v1.Pod) bool {
 	return pod.Status.Phase == v1.PodFailed && pod.Status.Reason == "Evicted"
@@ -42,3 +46,5 @@ func PodIsCompleted(pod *v1.Pod) bool {
 
 	return pod.Status.Phase == v1.PodSucceeded && unknownContainerCount == 0
 }
+
+var ParseNetworkConfigOfPodByPriority = utils.ParseNetworkConfigOfPodByPriority


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/hybridnet/blob/main/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

Pull Request Description
---

### Describe what this PR does / why we need it
Sometime we do not want an inactive webhook will block all pods' creation, especially most pods can be handled by pod controller normally.
So we need some extended checks in controller to handle some unexpected pods if webhook inactive and notice our users.

### Does this pull request fix one issue?
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
#301

### Describe how you did it
1. mark pods if it went through webhook
2. pod controller will do some extra validations on unmarked pods
3. pod controller will check the network config consistency (network, network-type...) between controller and webhook on unmarked pods

### Describe how to verify it
NONE

### Special notes for reviews
NONE