### PR TITLE
enhance: enable RecoverPanic to handle unexpected panics and avoid unnecessary restarts

### DIFF
--- a/pkg/controllers/multicluster/globalservice_controller.go
+++ b/pkg/controllers/multicluster/globalservice_controller.go
@@ -225,6 +225,7 @@ func (r *GlobalServiceReconciler) SetupWithManager(mgr ctrl.Manager) (err error)
 			)).
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: r.Max(),
+			RecoverPanic:            true,
 		}).
 		Complete(r)
 }

--- a/pkg/controllers/multicluster/remotecluster_controller.go
+++ b/pkg/controllers/multicluster/remotecluster_controller.go
@@ -157,6 +157,7 @@ func (r *RemoteClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		).
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: r.Max(),
+			RecoverPanic:            true,
 		}).
 		Complete(r)
 }

--- a/pkg/controllers/multicluster/remoteclusteruuid_controller.go
+++ b/pkg/controllers/multicluster/remoteclusteruuid_controller.go
@@ -127,6 +127,7 @@ func (r *RemoteClusterUUIDReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		).
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: r.Max(),
+			RecoverPanic:            true,
 		}).
 		Complete(r)
 }

--- a/pkg/controllers/multicluster/remoteendpointslice_controller.go
+++ b/pkg/controllers/multicluster/remoteendpointslice_controller.go
@@ -239,6 +239,7 @@ func (r *RemoteEndpointSliceReconciler) SetupWithManager(mgr ctrl.Manager) (err 
 		// TODO: Add periodic garbage collection?
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: 1,
+			RecoverPanic:            true,
 		}).
 		Complete(r)
 }

--- a/pkg/controllers/multicluster/remotesubnet_controller.go
+++ b/pkg/controllers/multicluster/remotesubnet_controller.go
@@ -160,6 +160,7 @@ func (r *RemoteSubnetReconciler) SetupWithManager(mgr ctrl.Manager) (err error) 
 		).
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: 1,
+			RecoverPanic:            true,
 		}).
 		Complete(r)
 }

--- a/pkg/controllers/multicluster/remotevtep_controller.go
+++ b/pkg/controllers/multicluster/remotevtep_controller.go
@@ -296,6 +296,7 @@ func (r *RemoteVtepReconciler) SetupWithManager(mgr ctrl.Manager) (err error) {
 		).
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: 1,
+			RecoverPanic:            true,
 		}).
 		Complete(r)
 }

--- a/pkg/controllers/networking/ipam_controller.go
+++ b/pkg/controllers/networking/ipam_controller.go
@@ -139,6 +139,7 @@ func (r *IPAMReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		WithOptions(
 			controller.Options{
 				MaxConcurrentReconciles: r.Max(),
+				RecoverPanic:            true,
 			}).
 		Complete(r)
 }

--- a/pkg/controllers/networking/ipinstance_controller.go
+++ b/pkg/controllers/networking/ipinstance_controller.go
@@ -90,6 +90,7 @@ func (r *IPInstanceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		)).
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: r.Max(),
+			RecoverPanic:            true,
 		}).
 		Complete(r)
 }

--- a/pkg/controllers/networking/networkstatus_controller.go
+++ b/pkg/controllers/networking/networkstatus_controller.go
@@ -293,6 +293,7 @@ func (r *NetworkStatusReconciler) SetupWithManager(mgr ctrl.Manager) (err error)
 		WithOptions(
 			controller.Options{
 				MaxConcurrentReconciles: r.Max(),
+				RecoverPanic:            true,
 			},
 		).
 		Complete(r)

--- a/pkg/controllers/networking/node_controller.go
+++ b/pkg/controllers/networking/node_controller.go
@@ -152,6 +152,7 @@ func (r *NodeReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		).
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: r.Max(),
+			RecoverPanic:            true,
 		}).
 		Complete(r)
 }

--- a/pkg/controllers/networking/pod_controller.go
+++ b/pkg/controllers/networking/pod_controller.go
@@ -748,6 +748,7 @@ func (r *PodReconciler) SetupWithManager(mgr ctrl.Manager) (err error) {
 		).
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: r.Max(),
+			RecoverPanic:            true,
 		}).
 		Complete(r)
 }

--- a/pkg/controllers/networking/quota_controller.go
+++ b/pkg/controllers/networking/quota_controller.go
@@ -144,6 +144,7 @@ func (r *QuotaReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		WithOptions(
 			controller.Options{
 				MaxConcurrentReconciles: r.Max(),
+				RecoverPanic:            true,
 			},
 		).
 		Complete(r)

--- a/pkg/controllers/networking/subnetstatus_controller.go
+++ b/pkg/controllers/networking/subnetstatus_controller.go
@@ -147,6 +147,7 @@ func (r *SubnetStatusReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		).
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: r.Max(),
+			RecoverPanic:            true,
 		}).
 		Complete(r)
 }

--- a/pkg/daemon/controller/ipinstance.go
+++ b/pkg/daemon/controller/ipinstance.go
@@ -160,7 +160,10 @@ func (r *ipInstanceReconciler) Reconcile(ctx context.Context, request reconcile.
 }
 
 func (r *ipInstanceReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	ipInstanceController, err := controller.New("ip-instance", mgr, controller.Options{Reconciler: r})
+	ipInstanceController, err := controller.New("ip-instance", mgr, controller.Options{
+		Reconciler:   r,
+		RecoverPanic: true,
+	})
 	if err != nil {
 		return fmt.Errorf("failed to create ip instance controller: %v", err)
 	}

--- a/pkg/daemon/controller/node.go
+++ b/pkg/daemon/controller/node.go
@@ -337,7 +337,10 @@ func checkNodeUpdate(updateEvent event.UpdateEvent) bool {
 }
 
 func (r *nodeReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	nodeController, err := controller.New("node", mgr, controller.Options{Reconciler: r})
+	nodeController, err := controller.New("node", mgr, controller.Options{
+		Reconciler:   r,
+		RecoverPanic: true,
+	})
 	if err != nil {
 		return fmt.Errorf("failed to create node controller: %v", err)
 	}

--- a/pkg/daemon/controller/subnet.go
+++ b/pkg/daemon/controller/subnet.go
@@ -188,7 +188,10 @@ func (r *subnetReconciler) Reconcile(ctx context.Context, request reconcile.Requ
 }
 
 func (r *subnetReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	subnetController, err := controller.New("subnet", mgr, controller.Options{Reconciler: r})
+	subnetController, err := controller.New("subnet", mgr, controller.Options{
+		Reconciler:   r,
+		RecoverPanic: true,
+	})
 	if err != nil {
 		return fmt.Errorf("failed to create subnet controller: %v", err)
 	}


### PR DESCRIPTION
Signed-off-by: Bruce Ma <brucema19901024@gmail.com>

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/hybridnet/blob/main/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

Pull Request Description
---

### Describe what this PR does / why we need it

To avoid manager/daemon restart when reconcile function panic.

### Does this pull request fix one issue?
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
#324 

### Describe how you did it

Enable `RecoverPanic` in controller-runtime.

### Describe how to verify it

### Special notes for reviews