### PR TITLE
modify ipv6 route cache gc parameters to adapt to kernel route error

### DIFF
--- a/pkg/constants/sysctl.go
+++ b/pkg/constants/sysctl.go
@@ -46,4 +46,7 @@ const (
 
 	IPv6DisableModuleParameter = "/sys/module/ipv6/parameters/disable"
 	IPv6DisableSysctl          = "/proc/sys/net/ipv6/conf/%s/disable_ipv6"
+
+	IPv6RouteCacheMaxSizeSysctl = "/proc/sys/net/ipv6/route/max_size"
+	IPv6RouteCacheGCThresh      = "/proc/sys/net/ipv6/route/gc_thresh"
 )

--- a/pkg/daemon/config/config.go
+++ b/pkg/daemon/config/config.go
@@ -51,6 +51,9 @@ const (
 	DefaultLocalDirectTableNum     = 39999
 	DefaultToOverlaySubnetTableNum = 40000
 	DefaultOverlayMarkTableNum     = 40001
+
+	DefaultIPv6RouteCacheMaxSize  = 524288
+	DefaultIPv6RouteCacheGCThresh = 65536
 )
 
 // Configuration is the daemon conf
@@ -94,6 +97,9 @@ type Configuration struct {
 	NeighGCThresh2 int
 	NeighGCThresh3 int
 
+	IPv6RouteCacheMaxSize  int
+	IPv6RouteCacheGCThresh int
+
 	EnableVlanArpEnhancement bool
 }
 
@@ -122,6 +128,8 @@ func ParseFlags() (*Configuration, error) {
 		argNeighGCThresh3                       = pflag.Int("neigh-gc-thresh3", DefaultNeighGCThresh3, "Value to set net.ipv4/ipv6.neigh.default.gc_thresh3")
 		argExtraNodeLocalVxlanIPCidrs           = pflag.String("extra-node-local-vxlan-ip-cidrs", "", "The cidr list to select node extra local vxlan ip, e.g., \"192.168.10.0/24,10.2.3.0/24\"")
 		argEnableVlanArpEnhancement             = pflag.Bool("enable-vlan-arp-enhancement", true, "Whether enable arp source enhancement in a vlan environment")
+		argIPv6RouteCacheMaxSize                = pflag.Int("ipv6-route-cache-max-size", DefaultIPv6RouteCacheMaxSize, "Value to set net.ipv6.route.max_size")
+		argIPv6RouteCacheGCThresh               = pflag.Int("ipv6-route-cache-gc-thresh", DefaultIPv6RouteCacheGCThresh, "Value to set net.ipv6.route.gc_thresh")
 	)
 
 	// mute info log for ipset lib
@@ -156,6 +164,8 @@ func ParseFlags() (*Configuration, error) {
 		NeighGCThresh3:                       *argNeighGCThresh3,
 		VxlanExpiredNeighCachesClearInterval: *argVxlanExpiredNeighCachesClearInterval,
 		EnableVlanArpEnhancement:             *argEnableVlanArpEnhancement,
+		IPv6RouteCacheMaxSize:                *argIPv6RouteCacheMaxSize,
+		IPv6RouteCacheGCThresh:               *argIPv6RouteCacheGCThresh,
 	}
 
 	if *argPreferVlanInterfaces == "" {

--- a/pkg/daemon/containernetwork/containernetwork.go
+++ b/pkg/daemon/containernetwork/containernetwork.go
@@ -155,7 +155,8 @@ func ConfigureHostNic(nicName string, allocatedIPs map[networkingv1.IPVersion]*d
 
 func ConfigureContainerNic(containerNicName, hostNicName, nodeIfName string, allocatedIPs map[networkingv1.IPVersion]*daemonutils.IPInfo,
 	macAddr net.HardwareAddr, netns ns.NetNS, mtu int, vlanCheckTimeout time.Duration, networkMode networkingv1.NetworkMode,
-	neighGCThresh1, neighGCThresh2, neighGCThresh3 int, bgpManager *bgp.Manager) error {
+	neighGCThresh1, neighGCThresh2, neighGCThresh3, ipv6RouteCacheMaxSize, ipv6RouteCacheGCThresh int,
+	bgpManager *bgp.Manager) error {
 
 	var defaultRouteNets []*types.Route
 	var ipConfigs []*current.IPConfig
@@ -253,6 +254,10 @@ func ConfigureContainerNic(containerNicName, hostNicName, nodeIfName string, all
 
 		if err := daemonutils.EnsureNeighGCThresh(netlink.FAMILY_V6, neighGCThresh1, neighGCThresh2, neighGCThresh3); err != nil {
 			return fmt.Errorf("failed to ensure ipv6 neigh gc thresh: %v", err)
+		}
+
+		if err := daemonutils.EnsureIPv6RouteGCParameters(ipv6RouteCacheMaxSize, ipv6RouteCacheGCThresh); err != nil {
+			return fmt.Errorf("failed to set ipv6 route cache gc parameters: %v", err)
 		}
 
 		if networkMode == networkingv1.NetworkModeVlan {

--- a/pkg/daemon/containernetwork/utils.go
+++ b/pkg/daemon/containernetwork/utils.go
@@ -78,13 +78,13 @@ func EnsureRpFilterConfigs(containerHostIf string) error {
 	for _, key := range []string{"default", "all"} {
 		sysctlPath := fmt.Sprintf(constants.RpFilterSysctl, key)
 		if err := daemonutils.SetSysctl(sysctlPath, 0); err != nil {
-			return fmt.Errorf("error set: %s sysctl path to 0, error: %v", sysctlPath, err)
+			return fmt.Errorf("failed to set %s sysctl path to 0, error: %v", sysctlPath, err)
 		}
 	}
 
 	sysctlPath := fmt.Sprintf(constants.RpFilterSysctl, containerHostIf)
 	if err := daemonutils.SetSysctl(sysctlPath, 0); err != nil {
-		return fmt.Errorf("error set: %s sysctl path to 0, error: %v", sysctlPath, err)
+		return fmt.Errorf("failed to set %s sysctl path to 0, error: %v", sysctlPath, err)
 	}
 
 	existInterfaces, err := net.Interfaces()
@@ -104,7 +104,7 @@ func EnsureRpFilterConfigs(containerHostIf string) error {
 		}
 		if sysctlValue != 0 {
 			if err = daemonutils.SetSysctl(sysctlPath, 0); err != nil {
-				return fmt.Errorf("error set: %s sysctl path to 0, error: %v", sysctlPath, err)
+				return fmt.Errorf("failed to set %s sysctl path to 0, error: %v", sysctlPath, err)
 			}
 		}
 	}

--- a/pkg/daemon/server/container.go
+++ b/pkg/daemon/server/container.go
@@ -76,7 +76,8 @@ func (cdh cniDaemonHandler) configureNic(podName, podNamespace, netns, mac strin
 
 	if err = containernetwork.ConfigureContainerNic(containerNicName, hostNicName, nodeIfName,
 		allocatedIPs, macAddr, podNS, mtu, cdh.config.VlanCheckTimeout, networkMode,
-		cdh.config.NeighGCThresh1, cdh.config.NeighGCThresh2, cdh.config.NeighGCThresh3, cdh.bgpManager); err != nil {
+		cdh.config.NeighGCThresh1, cdh.config.NeighGCThresh2, cdh.config.NeighGCThresh3, cdh.config.IPv6RouteCacheMaxSize,
+		cdh.config.IPv6RouteCacheGCThresh, cdh.bgpManager); err != nil {
 		return "", fmt.Errorf("failed to configure container nic for %v.%v: %v", podName, podNamespace, err)
 	}
 

--- a/pkg/daemon/utils/network.go
+++ b/pkg/daemon/utils/network.go
@@ -328,7 +328,7 @@ func EnsureNeighGCThresh(family int, neighGCThresh1, neighGCThresh2, neighGCThre
 		//     purge entries if there are fewer than this number.
 		//     Default: 128
 		if err := SetSysctl(constants.IPv4NeighGCThresh1, neighGCThresh1); err != nil {
-			return fmt.Errorf("error set: %s sysctl path to %v, error: %v", constants.IPv4NeighGCThresh1, neighGCThresh1, err)
+			return fmt.Errorf("failed to set %s sysctl path to %v, error: %v", constants.IPv4NeighGCThresh1, neighGCThresh1, err)
 		}
 
 		// From kernel doc:
@@ -338,7 +338,7 @@ func EnsureNeighGCThresh(family int, neighGCThresh1, neighGCThresh2, neighGCThre
 		//     when over this number.
 		//     Default: 512
 		if err := SetSysctl(constants.IPv4NeighGCThresh2, neighGCThresh2); err != nil {
-			return fmt.Errorf("error set: %s sysctl path to %v, error: %v", constants.IPv4NeighGCThresh2, neighGCThresh2, err)
+			return fmt.Errorf("failed to set %s sysctl path to %v, error: %v", constants.IPv4NeighGCThresh2, neighGCThresh2, err)
 		}
 
 		// From kernel doc:
@@ -348,22 +348,22 @@ func EnsureNeighGCThresh(family int, neighGCThresh1, neighGCThresh2, neighGCThre
 		//     with large numbers of directly-connected peers.
 		//     Default: 1024
 		if err := SetSysctl(constants.IPv4NeighGCThresh3, neighGCThresh3); err != nil {
-			return fmt.Errorf("error set: %s sysctl path to %v, error: %v", constants.IPv4NeighGCThresh3, neighGCThresh3, err)
+			return fmt.Errorf("failed to set %s sysctl path to %v, error: %v", constants.IPv4NeighGCThresh3, neighGCThresh3, err)
 		}
 
 		return nil
 	}
 
 	if err := SetSysctl(constants.IPv6NeighGCThresh1, neighGCThresh1); err != nil {
-		return fmt.Errorf("error set: %s sysctl path to %v, error: %v", constants.IPv6NeighGCThresh1, neighGCThresh1, err)
+		return fmt.Errorf("failed to set %s sysctl path to %v, error: %v", constants.IPv6NeighGCThresh1, neighGCThresh1, err)
 	}
 
 	if err := SetSysctl(constants.IPv6NeighGCThresh2, neighGCThresh2); err != nil {
-		return fmt.Errorf("error set: %s sysctl path to %v, error: %v", constants.IPv6NeighGCThresh2, neighGCThresh2, err)
+		return fmt.Errorf("failed to set %s sysctl path to %v, error: %v", constants.IPv6NeighGCThresh2, neighGCThresh2, err)
 	}
 
 	if err := SetSysctl(constants.IPv6NeighGCThresh3, neighGCThresh3); err != nil {
-		return fmt.Errorf("error set: %s sysctl path to %v, error: %v", constants.IPv6NeighGCThresh3, neighGCThresh3, err)
+		return fmt.Errorf("failed to set %s sysctl path to %v, error: %v", constants.IPv6NeighGCThresh3, neighGCThresh3, err)
 	}
 
 	return nil
@@ -380,11 +380,11 @@ func EnsureIPv6RouteGCParameters(routeCacheMaxSize, gcThresh int) error {
 	// kernel patch is founded.
 
 	if err := SetSysctl(constants.IPv6RouteCacheMaxSizeSysctl, routeCacheMaxSize); err != nil {
-		return fmt.Errorf("error set: %s sysctl path to %v, error: %v", constants.IPv6RouteCacheMaxSizeSysctl, routeCacheMaxSize, err)
+		return fmt.Errorf("failed to set %s sysctl path to %v, error: %v", constants.IPv6RouteCacheMaxSizeSysctl, routeCacheMaxSize, err)
 	}
 
 	if err := SetSysctl(constants.IPv6RouteCacheGCThresh, gcThresh); err != nil {
-		return fmt.Errorf("error set: %s sysctl path to %v, error: %v", constants.IPv6RouteCacheGCThresh, gcThresh, err)
+		return fmt.Errorf("failed to set %s sysctl path to %v, error: %v", constants.IPv6RouteCacheGCThresh, gcThresh, err)
 	}
 	return nil
 }


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/hybridnet/blob/main/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

Pull Request Description
---

### Describe what this PR does / why we need it
IPv6 traffic's being dropped happens suddenly in some kernel versions (e.g., 4.18.0-80.el8.x86_64 of CentOS 8), while running "ip route get" for some of the ipv6 routes in table 39999 you can get a "Network is unreachable" error (though you can see a obviously correct route table configuration by running "ip route show"), and all neighbors are invalidated at the same time. This problem will shutdown all the Pods' network on the same node.

We believed that this problem is related to the kernel GC mechanism of ipv6 route cache because errors disappeared when the "net.ipv6.route.max_size" kernel parameter was configured to a much larger one (default 4096). But no related kernel patch is founded.

### Does this pull request fix one issue?
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it

### Describe how to verify it

### Special notes for reviews