### PR TITLE
ensure felix ready before start pod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/coreos/go-iptables v0.6.0
 	github.com/emicklei/go-restful v2.16.0+incompatible
 	github.com/go-logr/logr v1.2.3
+	github.com/go-ping/ping v1.1.0
 	github.com/gogf/gf v1.16.6
 	github.com/heptiolabs/healthcheck v0.0.0-20211123025425-613501dd5deb
 	github.com/mdlayher/ethernet v0.0.0-20190606142754-0394541c37b7
@@ -85,6 +86,7 @@ require (
 	go.uber.org/zap v1.19.1 // indirect
 	golang.org/x/net v0.0.0-20220826154423-83b083e8dc8b // indirect
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8 // indirect
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/xerrors v0.0.0-20220609144429-65e65417b02f // indirect

--- a/go.sum
+++ b/go.sum
@@ -323,6 +323,8 @@ github.com/go-openapi/validate v0.18.0/go.mod h1:Uh4HdOzKt19xGIGm1qHf/ofbX1YQ4Y+
 github.com/go-openapi/validate v0.19.2/go.mod h1:1tRCw7m3jtI8eNWEEliiAqUIcBztB2KDnRCRMUi7GTA=
 github.com/go-openapi/validate v0.19.5/go.mod h1:8DJv2CVJQ6kGNpFW6eV9N3JviE1C85nY1c2z52x1Gk4=
 github.com/go-ozzo/ozzo-validation v3.5.0+incompatible/go.mod h1:gsEKFIVnabGBt6mXmxK0MoFy+cZoTJY6mu5Ll3LVLBU=
+github.com/go-ping/ping v1.1.0 h1:3MCGhVX4fyEUuhsfwPrsEdQw6xspHkv5zHsiSoDFZYw=
+github.com/go-ping/ping v1.1.0/go.mod h1:xIFjORFzTxqIV/tDVGO4eDy/bLuSyawEeojSm3GfRGk=
 github.com/go-sql-driver/mysql v1.6.0 h1:BCTh4TKNUYmOmMUcQ3IipzF5prigylS7XXjEkfCHuOE=
 github.com/go-sql-driver/mysql v1.6.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
@@ -421,6 +423,7 @@ github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
@@ -1022,6 +1025,7 @@ golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/pkg/constants/annotations.go
+++ b/pkg/constants/annotations.go
@@ -36,4 +36,6 @@ const (
 	AnnotationNodeLocalVxlanIPList = "networking.alibaba.com/local-vxlan-ip-list"
 
 	AnnotationHandledByWebhook = "networking.alibaba.com/handled-by-webhook"
+
+	AnnotationCalicoPodIPs = "cni.projectcalico.org/podIPs"
 )

--- a/pkg/daemon/bgp/bgp.go
+++ b/pkg/daemon/bgp/bgp.go
@@ -80,7 +80,7 @@ func NewManager(peeringInterfaceName, grpcListenAddress string, logger logr.Logg
 		return nil, fmt.Errorf("failed to get bgp peering link %v: %v", peeringInterfaceName, err)
 	}
 
-	existLinkAddress, err := daemonutils.ListAllAddress(peeringLink)
+	existLinkAddress, err := daemonutils.ListAllGlobalUnicastAddress(peeringLink)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get link address for bgp peering interface %v: %v", peeringInterfaceName, err)
 	}

--- a/pkg/daemon/config/config.go
+++ b/pkg/daemon/config/config.go
@@ -100,7 +100,9 @@ type Configuration struct {
 	IPv6RouteCacheMaxSize  int
 	IPv6RouteCacheGCThresh int
 
-	EnableVlanArpEnhancement bool
+	EnableVlanArpEnhancement     bool
+	PatchCalicoPodIPsAnnotation  bool
+	CheckPodConnectivityFromHost bool
 }
 
 // ParseFlags will parse cmd args then init kubeClient and configuration
@@ -130,6 +132,8 @@ func ParseFlags() (*Configuration, error) {
 		argEnableVlanArpEnhancement             = pflag.Bool("enable-vlan-arp-enhancement", true, "Whether enable arp source enhancement in a vlan environment")
 		argIPv6RouteCacheMaxSize                = pflag.Int("ipv6-route-cache-max-size", DefaultIPv6RouteCacheMaxSize, "Value to set net.ipv6.route.max_size")
 		argIPv6RouteCacheGCThresh               = pflag.Int("ipv6-route-cache-gc-thresh", DefaultIPv6RouteCacheGCThresh, "Value to set net.ipv6.route.gc_thresh")
+		argPatchCalicoPodIPsAnnotation          = pflag.Bool("patch-calico-pod-ips-annotation", true, "Patch \"cni.projectcalico.org/podIPs\" annotations to pod")
+		argCheckPodConnectivityFromHost         = pflag.Bool("check-pod-connectivity-from-host", true, "Check pod's connectivity from host before start it")
 	)
 
 	// mute info log for ipset lib
@@ -166,6 +170,8 @@ func ParseFlags() (*Configuration, error) {
 		EnableVlanArpEnhancement:             *argEnableVlanArpEnhancement,
 		IPv6RouteCacheMaxSize:                *argIPv6RouteCacheMaxSize,
 		IPv6RouteCacheGCThresh:               *argIPv6RouteCacheGCThresh,
+		PatchCalicoPodIPsAnnotation:          *argPatchCalicoPodIPsAnnotation,
+		CheckPodConnectivityFromHost:         *argCheckPodConnectivityFromHost,
 	}
 
 	if *argPreferVlanInterfaces == "" {

--- a/pkg/daemon/containernetwork/utils.go
+++ b/pkg/daemon/containernetwork/utils.go
@@ -24,9 +24,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/alibaba/hybridnet/pkg/constants"
+	"github.com/go-ping/ping"
 
 	networkingv1 "github.com/alibaba/hybridnet/pkg/apis/networking/v1"
+	"github.com/alibaba/hybridnet/pkg/constants"
 	"github.com/alibaba/hybridnet/pkg/daemon/bgp"
 	daemonutils "github.com/alibaba/hybridnet/pkg/daemon/utils"
 	"github.com/vishvananda/netlink"
@@ -62,7 +63,7 @@ func ListLocalAddressExceptLink(exceptLinkName string) ([]netlink.Addr, error) {
 		linkName := link.Attrs().Name
 		if linkName != exceptLinkName && !CheckIfContainerNetworkLink(linkName) {
 
-			linkAddrList, err := daemonutils.ListAllAddress(link)
+			linkAddrList, err := daemonutils.ListAllGlobalUnicastAddress(link)
 			if err != nil {
 				return nil, fmt.Errorf("failed to link addr for link %v: %v", link.Attrs().Name, err)
 			}
@@ -197,6 +198,44 @@ func checkPodNetConfigReady(podIP net.IP, podCidr *net.IPNet, forwardNodeIfIndex
 
 		time.Sleep(backOffBase)
 		backOffBase = backOffBase * 2
+	}
+
+	return nil
+}
+
+func CheckReachabilityFromHost(target net.IP, family int) error {
+	addressList, err := daemonutils.ListGlobalUnicastAddress(nil, family)
+	if err != nil {
+		return fmt.Errorf("failed to list global unicase addresses: %v", err)
+	}
+
+	const retries = 5
+	interval := time.Second
+
+	if len(addressList) != 0 {
+		pinger, err := ping.NewPinger(target.String())
+		if err != nil {
+			return fmt.Errorf("failed to init pinger: %v", err)
+		}
+
+		pinger.SetPrivileged(true)
+		pinger.Count = retries
+		pinger.Timeout = retries * interval
+		pinger.Interval = interval
+
+		var success bool
+		pinger.OnRecv = func(p *ping.Packet) {
+			success = true
+			pinger.Stop()
+		}
+
+		if err = pinger.Run(); err != nil {
+			return fmt.Errorf("failed to run pinger: %v", err)
+		}
+
+		if !success {
+			return fmt.Errorf("pod network not ready after %d ping %s", retries, target)
+		}
 	}
 
 	return nil

--- a/pkg/daemon/controller/node.go
+++ b/pkg/daemon/controller/node.go
@@ -201,7 +201,7 @@ func (r *nodeReconciler) selectVtepAddressFromLink() (net.IP, net.HardwareAddr, 
 	}
 
 	// Use parent's valid ipv4 address first, try ipv6 address if no valid ipv4 address exist.
-	existParentAddrList, err := utils.ListAllAddress(link)
+	existParentAddrList, err := utils.ListAllGlobalUnicastAddress(link)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to list address for vxlan parent link %v: %v",
 			link.Attrs().Name, err)
@@ -286,7 +286,7 @@ func ensureVxlanInterfaceAddresses(vxlanDev *vxlan.Device, addresses []netlink.A
 		nodeLocalVxlanAddrMap[addr.IP.String()] = true
 	}
 
-	vxlanDevAddrList, err := utils.ListAllAddress(vxlanDev.Link())
+	vxlanDevAddrList, err := utils.ListAllGlobalUnicastAddress(vxlanDev.Link())
 	if err != nil {
 		return fmt.Errorf("failed to list address for vxlan interface %v: %v",
 			vxlanDev.Link().Name, err)

--- a/pkg/daemon/server/container.go
+++ b/pkg/daemon/server/container.go
@@ -81,6 +81,30 @@ func (cdh cniDaemonHandler) configureNic(podName, podNamespace, netns, mac strin
 		return "", fmt.Errorf("failed to configure container nic for %v.%v: %v", podName, podNamespace, err)
 	}
 
+	if allocatedIPs[networkingv1.IPv4] != nil {
+		podIP := allocatedIPs[networkingv1.IPv4].Addr
+
+		if cdh.config.CheckPodConnectivityFromHost {
+			// ICMP traffic from pod's node to pod is always assumed allowed.
+			// If the node has an usable ip, check the local pod's connectivity from node.
+			if err := containernetwork.CheckReachabilityFromHost(podIP, netlink.FAMILY_V4); err != nil {
+				return "", fmt.Errorf("falied to check the connectivity of local pod ip %v: %v", podIP, err)
+			}
+		}
+	}
+
+	if allocatedIPs[networkingv1.IPv6] != nil {
+		podIP := allocatedIPs[networkingv1.IPv6].Addr
+
+		if cdh.config.CheckPodConnectivityFromHost {
+			// ICMP traffic from pod's node to pod is always assumed allowed.
+			// If the node has an usable ip, check the local pod's connectivity from node.
+			if err := containernetwork.CheckReachabilityFromHost(podIP, netlink.FAMILY_V6); err != nil {
+				return "", fmt.Errorf("falied to check the connectivity of local pod ip %v: %v", podIP, err)
+			}
+		}
+	}
+
 	return hostNicName, nil
 }
 


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/hybridnet/blob/main/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

Pull Request Description
---

### Describe what this PR does / why we need it
Using felix as the NetworkPolicy implementation, pod will always be in `ContainerCreating` status if it has networking operations in its PostStart lifecycle hook.

> At that moment, pod is not even pingable from the pod's local node.

The root problem is that Kubernetes isn't updating the `podIP` field while the container lifecycle hooks are firing. Without this felix doesn't learn the pod's IP address and can't properly set up policy. Currently this seems to only be set after the pod moves out of ContainerCreating phase. Refer to https://github.com/projectcalico/calico/issues/3499.

This PR can resolve the problem properly.

### Does this pull request fix one issue?
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
NONE

### Describe how you did it
1. Introduce a `--patch-calico-pod-ips-annotation` flag for hybridnet daemon. If it's enabled, daemon will patch a `cni.projectcalico.org/podIPs` annotation to make felix be aware of what the pod's ip addresses are before initializing the pod's netns.
2. Introduce a `--check-pod-connectivity-from-host` flag for daemon. If it's enabled, daemon will check if the pod is pingable  before finishing initializing the pod's netns and fail if the pod is unpingable.

> PS: If the `--check-pod-connectivity-from-host` flag is enabled but `--patch-calico-pod-ips-annotation` is not, in a hybridnet-felix environment, pod will always be `ContainerCreating`.

### Describe how to verify it
To create a pod like:

```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: ping-test2
spec:
  selector:
    matchLabels:
      app: ping-test2
  replicas: 1
  template:
    metadata:
      labels:
        app: ping-test2
    spec:
      containers:
      - name: ping
        image: hybridnet:v0.6.0
        command: ['bash', '-c', 'ping 8.8.8.8']
        lifecycle:
          postStart:
            exec:
              command:
              - bash
              - -c
              - 'ping -c 1 8.8.8.8 -W 600'
```


### Special notes for reviews