### PR TITLE
fix: use correct cidr utils to calculate subnet capacity

### DIFF
--- a/pkg/apis/networking/v1/utils.go
+++ b/pkg/apis/networking/v1/utils.go
@@ -19,7 +19,6 @@ package v1
 import (
 	"fmt"
 	"math"
-	"math/big"
 	"net"
 	"strconv"
 	"strings"
@@ -206,17 +205,17 @@ func CalculateCapacity(ar *AddressRange) int64 {
 		start = net.ParseIP(ar.Start)
 	}
 	if start == nil {
-		start = nextIP(cidr.IP)
+		start = utils.NextIP(cidr.IP)
 	}
 
 	if len(ar.End) > 0 {
 		end = net.ParseIP(ar.End)
 	}
 	if end == nil {
-		end = lastIP(cidr)
+		end = utils.LastIP(cidr)
 	}
 
-	return capacity(start, end) - int64(len(ar.ExcludeIPs))
+	return utils.Capacity(start, end) - int64(len(ar.ExcludeIPs))
 }
 
 func IsAvailable(statistics *Count) bool {
@@ -279,40 +278,6 @@ func Intersect(rangeA *AddressRange, rangeB *AddressRange) bool {
 		}
 	}
 	return false
-}
-
-func lastIP(subnet *net.IPNet) net.IP {
-	var end net.IP
-	for i := 0; i < len(subnet.IP); i++ {
-		end = append(end, subnet.IP[i]|^subnet.Mask[i])
-	}
-	if subnet.IP.To4() != nil {
-		end[3]--
-	}
-
-	return end
-}
-
-func nextIP(ip net.IP) net.IP {
-	i := ipToInt(ip)
-	return intToIP(i.Add(i, big.NewInt(1)))
-}
-
-func capacity(a, b net.IP) int64 {
-	aa := ipToInt(a)
-	bb := ipToInt(b)
-	return big.NewInt(0).Sub(bb, aa).Int64() + 1
-}
-
-func ipToInt(ip net.IP) *big.Int {
-	if v := ip.To4(); v != nil {
-		return big.NewInt(0).SetBytes(v)
-	}
-	return big.NewInt(0).SetBytes(ip.To16())
-}
-
-func intToIP(i *big.Int) net.IP {
-	return net.IP(i.Bytes())
 }
 
 // IsLegacyModel will show whether IPInstance has switched to new version

--- a/pkg/apis/networking/v1/utils_test.go
+++ b/pkg/apis/networking/v1/utils_test.go
@@ -257,6 +257,34 @@ func TestCalculateCapacity(t *testing.T) {
 			},
 			99,
 		},
+		{
+			"only cidr, starts with IP like 0.x.x.x",
+			&AddressRange{
+				CIDR: "0.1.0.0/22",
+			},
+			1022,
+		},
+		{
+			"cidr, starts with IP like 0.x.x.x",
+			&AddressRange{
+				CIDR:  "0.0.1.1/24",
+				Start: "0.0.1.100",
+			},
+			155,
+		},
+		{
+			"cidr, all set, starts with IP like 0.x.x.x",
+			&AddressRange{
+				Start: "0.1.0.100",
+				End:   "0.1.0.200",
+				CIDR:  "0.1.0.0/24",
+				ExcludeIPs: []string{
+					"0.0.0.198",
+					"0.0.1.199",
+				},
+			},
+			99,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/pkg/utils/cidr.go
+++ b/pkg/utils/cidr.go
@@ -59,6 +59,23 @@ func Cmp(a, b net.IP) int {
 	return -2
 }
 
+// Capacity returns the absolute number of IPs between a and b.
+// 0 is returned if a and b are of different IP families, or
+// any of those two IPs is invalid.
+func Capacity(a, b net.IP) int64 {
+	normalizedA := normalizeIP(a)
+	normalizedB := normalizeIP(b)
+
+	if normalizedA == nil || normalizedB == nil || len(normalizedA) != len(normalizedB) {
+		return 0
+	}
+
+	ai := ipToInt(normalizedA)
+	bi := ipToInt(normalizedB)
+
+	return big.NewInt(0).Abs(big.NewInt(0).Sub(bi, ai)).Int64() + 1
+}
+
 func ipToInt(ip net.IP) *big.Int {
 	return big.NewInt(0).SetBytes(ip)
 }

--- a/pkg/utils/cidr_test.go
+++ b/pkg/utils/cidr_test.go
@@ -179,6 +179,56 @@ func TestCmpIP(t *testing.T) {
 	}
 }
 
+func TestCapacity(t *testing.T) {
+	testCases := []struct {
+		a      net.IP
+		b      net.IP
+		result int64
+	}{
+		{
+			net.ParseIP("192.168.0.1"),
+			net.ParseIP("192.168.0.2"),
+			2,
+		},
+		{
+			net.ParseIP("192.168.0.1"),
+			net.ParseIP("192.168.0.1"),
+			1,
+		},
+		{
+			net.ParseIP("192.168.0.1"),
+			net.ParseIP("AB12::210"),
+			0,
+		},
+		{
+			net.ParseIP("192.168.0.2"),
+			[]byte{192, 168, 5},
+			0,
+		},
+		{
+			net.ParseIP("AB12::123"),
+			net.ParseIP("AB12::210"),
+			238,
+		},
+		{
+			net.ParseIP("AB12::210"),
+			net.ParseIP("AB12::123"),
+			238,
+		},
+		{
+			net.ParseIP("AB12::123"),
+			net.ParseIP("AB12::123"),
+			1,
+		},
+	}
+	for _, test := range testCases {
+		outcome := Capacity(test.a, test.b)
+		if outcome != test.result {
+			t.Errorf("expect result %d but got %d", test.result, outcome)
+		}
+	}
+}
+
 func TestNetwork(t *testing.T) {
 	testCases := []struct {
 		ipNet  *net.IPNet


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/hybridnet/blob/main/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

Pull Request Description
---

### Describe what this PR does / why we need it

### Does this pull request fix one issue?
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
fix #347 

### Describe how you did it
Remove flawed util funcs, and use correct cidr utils to calculate subnet capacity.

### Describe how to verify it

### Special notes for reviews