### PR TITLE
switch ioutil to os because deprecation

### DIFF
--- a/pkg/daemon/neigh/neigh.go
+++ b/pkg/daemon/neigh/neigh.go
@@ -18,8 +18,8 @@ package neigh
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net"
+	"os"
 	"strconv"
 
 	"github.com/vishvananda/netlink"
@@ -70,7 +70,7 @@ func (m *Manager) SyncNeighs() error {
 		if m.family == netlink.FAMILY_V6 {
 			// For ipv6, proxy_ndp need to be set.
 			sysctlPath := fmt.Sprintf("/proc/sys/net/ipv6/conf/%s/proxy_ndp", forwardNodeIfName)
-			if err := ioutil.WriteFile(sysctlPath, []byte(strconv.Itoa(1)), 0640); err != nil {
+			if err := os.WriteFile(sysctlPath, []byte(strconv.Itoa(1)), 0640); err != nil {
 				return fmt.Errorf("failed to set sysctl parameter %v: %v", sysctlPath, err)
 			}
 		}

--- a/pkg/daemon/utils/utils.go
+++ b/pkg/daemon/utils/utils.go
@@ -17,7 +17,6 @@
 package utils
 
 import (
-	"io/ioutil"
 	"os"
 	"strconv"
 	"strings"
@@ -69,11 +68,11 @@ func IsFs(path string, magic int64) bool {
 
 // SetSysctl modifies the specified sysctl flag to the new value
 func SetSysctl(sysctlPath string, newVal int) error {
-	return ioutil.WriteFile(sysctlPath, []byte(strconv.Itoa(newVal)), 0640)
+	return os.WriteFile(sysctlPath, []byte(strconv.Itoa(newVal)), 0640)
 }
 
 func SetSysctlIgnoreNotExist(sysctlPath string, newVal int) error {
-	err := ioutil.WriteFile(sysctlPath, []byte(strconv.Itoa(newVal)), 0640)
+	err := os.WriteFile(sysctlPath, []byte(strconv.Itoa(newVal)), 0640)
 
 	if os.IsNotExist(err) {
 		return nil
@@ -83,7 +82,7 @@ func SetSysctlIgnoreNotExist(sysctlPath string, newVal int) error {
 
 // GetSysctl modifies the specified sysctl flag to the new value
 func GetSysctl(sysctlPath string) (int, error) {
-	data, err := ioutil.ReadFile(sysctlPath)
+	data, err := os.ReadFile(sysctlPath)
 	if err != nil {
 		return -1, err
 	}


### PR DESCRIPTION
Signed-off-by: Bruce Ma <brucema19901024@gmail.com>

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/hybridnet/blob/main/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

Pull Request Description
---

### Describe what this PR does / why we need it

The io/ioutil package has been deprecated in Go 1.16 (See https://pkg.go.dev/io/ioutil). This PR replaces the existing io/ioutil functions with their new definitions in io and os packages.

ref to [https://github.com/containernetworking/cni/pull/932](https://github.com/containernetworking/cni/pull/932)

### Does this pull request fix one issue?
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
NONE

### Describe how you did it
NONE

### Describe how to verify it
NONE

### Special notes for reviews