### PR TITLE
Update network.go

### DIFF
--- a/pkg/daemon/utils/network.go
+++ b/pkg/daemon/utils/network.go
@@ -45,7 +45,7 @@ func GenerateVlanNetIfName(parentName string, vlanID *int32) (string, error) {
 		return "", fmt.Errorf("vlan id should not be nil")
 	}
 
-	if *vlanID > 4096 {
+	if *vlanID > 4094 {
 		return "", fmt.Errorf("vlan id's value range is from 0 to 4094")
 	}
 


### PR DESCRIPTION
as mentioned in issue [#350](https://github.com/alibaba/hybridnet/issues/350)  
vlanId should not be greater than 4094

---
### Describe what this PR does / why we need it
vanId range bugfix

### Does this pull request fix one issue?
Fixes [#350](https://github.com/alibaba/hybridnet/issues/350)  

### Describe how you did it
changed 4096 to 4094
### Describe how to verify it

### Special notes for reviews