### PR TITLE
handle terminating stateful or vm pods with no owner reference

### DIFF
--- a/pkg/controllers/networking/pod_controller.go
+++ b/pkg/controllers/networking/pod_controller.go
@@ -111,7 +111,36 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result
 	}
 
 	if pod.DeletionTimestamp != nil {
-		if strategy.OwnByStatefulWorkload(pod) {
+		var ownedObj client.Object = pod
+
+		// For terminating pods with no controller owner reference, try to get
+		// owner reference from ip instance.
+		if metav1.GetControllerOf(pod) == nil {
+			var ipInstanceList = &networkingv1.IPInstanceList{}
+			if err = r.List(ctx, ipInstanceList,
+				client.MatchingLabels{constants.LabelPod: pod.Name},
+				client.InNamespace(pod.Namespace),
+			); err != nil {
+				return ctrl.Result{}, wrapError("failed to list ip instance for pod", err)
+			}
+			for i := range ipInstanceList.Items {
+				ipInstance := &ipInstanceList.Items[i]
+				if !ipInstance.DeletionTimestamp.IsZero() {
+					continue
+				}
+				if metav1.GetControllerOf(ipInstance) != nil {
+					ownedObj = ipInstance.DeepCopy()
+					break
+				}
+			}
+
+			// If we still cannot find owner ref on all related ip instances, just remove pod finalizer.
+			if metav1.GetControllerOf(ownedObj) == nil {
+				return ctrl.Result{}, wrapError("unable to remove finalizer", r.removeFinalizer(ctx, pod))
+			}
+		}
+
+		if strategy.OwnByStatefulWorkload(ownedObj) {
 			if err = r.reserve(ctx, pod); err != nil {
 				return ctrl.Result{}, wrapError("unable to reserve pod", err)
 			}
@@ -120,7 +149,7 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result
 
 		if feature.VMIPRetainEnabled() {
 			// TODO: use APIReader to get VM/VMI object, because watch v1.VirtualMachine and v1.VirtualMachineInstance will always get errors
-			if isVMPod, vmName, _, err := strategy.OwnByVirtualMachine(ctx, pod, r.APIReader); isVMPod {
+			if isVMPod, vmName, _, err := strategy.OwnByVirtualMachine(ctx, ownedObj, r.APIReader); isVMPod {
 				vm := &kubevirtv1.VirtualMachine{}
 				if err = r.APIReader.Get(ctx, apitypes.NamespacedName{
 					Name:      vmName,
@@ -479,7 +508,7 @@ func (r *PodReconciler) statefulAllocate(ctx context.Context, pod *corev1.Pod, n
 func (r *PodReconciler) vmAllocate(ctx context.Context, pod *corev1.Pod, vmName, networkName, subnetStrFromWebhook string,
 	handledByWebhook bool, vmiOwnerReference *metav1.OwnerReference, ipFamily types.IPFamilyMode) (err error) {
 	if err = r.addFinalizer(ctx, pod); err != nil {
-		return wrapError("unable to add finalizer for stateful pod", err)
+		return wrapError("unable to add finalizer for vm pod", err)
 	}
 
 	vmLabels := client.MatchingLabels{
@@ -742,7 +771,16 @@ func (r *PodReconciler) SetupWithManager(mgr ctrl.Manager) (err error) {
 					ownByVMI, _ := strategy.OwnByVirtualMachineInstance(pod)
 
 					// terminating pods owned by stateful workloads and VMs should be processed for IP reservation
-					return strategy.OwnByStatefulWorkload(pod) || ownByVMI
+					if strategy.OwnByStatefulWorkload(pod) || ownByVMI {
+						return true
+					}
+
+					// It is possible that stateful or vm pod's controller owner
+					// reference is removed by gc controller during fore-terminating
+					// phase, so we allow handling such kind of pods as long as
+					// they got ip allocated finalizer.
+					return metav1.GetControllerOf(pod) == nil &&
+						controllerutil.ContainsFinalizer(pod, constants.FinalizerIPAllocated)
 				}),
 			),
 		).


### PR DESCRIPTION


<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/hybridnet/blob/main/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

Pull Request Description
---

### Describe what this PR does / why we need it
It is possible that stateful (or vm) pod's owner reference is removed by generic garbage collection controller during fore-terminating phase, and we ought to allow pod controller to handle such kind of pods as long as they got ip-allocated finalizer.

### Does this pull request fix one issue?
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
NONE

### Describe how you did it
When handling terminating pods with no owner reference, fall back to looking up owner reference on corresponding IPInstances. If still got no owner reference, just remove pod's finalizer (which should be safe) and end this reconciliation.

### Describe how to verify it

### Special notes for reviews