### PR TITLE
controller: skip unscheduled pods in pod reconciliation

### DIFF
--- a/pkg/controllers/utils/pod.go
+++ b/pkg/controllers/utils/pod.go
@@ -47,4 +47,8 @@ func PodIsCompleted(pod *v1.Pod) bool {
 	return pod.Status.Phase == v1.PodSucceeded && unknownContainerCount == 0
 }
 
+func PodIsScheduled(pod *v1.Pod) bool {
+	return len(pod.Spec.NodeName) > 0
+}
+
 var ParseNetworkConfigOfPodByPriority = utils.ParseNetworkConfigOfPodByPriority


### PR DESCRIPTION
Signed-off-by: Bruce Ma <brucema19901024@gmail.com>

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/hybridnet/blob/main/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

Pull Request Description
---

### Describe what this PR does / why we need it
avoid reconciling unscheduled pods

### Does this pull request fix one issue?
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
Fix #351

### Describe how you did it
check whether pod scheduled both in predication and reconciliation

### Describe how to verify it
NONE

### Special notes for reviews
NONE