### PR TITLE
chart: mount /var/run/netns for containerd

### DIFF
--- a/charts/hybridnet/Chart.yaml
+++ b/charts/hybridnet/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: hybridnet
 # When the version is modified, make sure the artifacthub.io/changes list is updated
 # Also update CHANGELOG.md
-version: 0.5.11
+version: 0.5.12
 appVersion: 0.7.7
 home: https://github.com/alibaba/hybridnet
 description: A container networking solution aiming at hybrid clouds.
@@ -22,5 +22,4 @@ annotations:
   artifacthub.io/prerelease: "false"
   # List of changes for the release in artifacthub.io
   artifacthub.io/changes: |
-    - "remove useless host var directory volume"
-    - "add nodeSelector parameters"
+    - "mount cni hostPath directory for containerd"

--- a/charts/hybridnet/templates/daemonsets.yaml
+++ b/charts/hybridnet/templates/daemonsets.yaml
@@ -111,6 +111,9 @@ spec:
               name: host-modules
             - mountPath: /run/xtables.lock
               name: xtables-lock
+            - mountPath: /var/run/netns
+              name: host-netns-dir
+              mountPropagation: Bidirectional
         {{ if .Values.daemon.enableFelixPolicy }}
         - name: felix
           image: "{{ .Values.images.registryURL }}/{{ .Values.images.hybridnet.image }}:{{ .Values.images.hybridnet.tag }}"
@@ -176,4 +179,7 @@ spec:
             items:
               - key: cni-config
                 path: cni-config
+        - name: host-netns-dir
+          hostPath:
+            path: /var/run/netns
 


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/hybridnet/blob/main/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

Pull Request Description
---

### Describe what this PR does / why we need it
`/var/run` hostPath volume was removed in #358 , this breaks pod's creation in containerd evironments. We need `/var/run/netns` to find netns for containerd Pods.

### Does this pull request fix one issue?
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it

### Describe how to verify it

### Special notes for reviews