### PR TITLE
fix: ipv6 subnet capacity calculation error because of int64 overflow

### DIFF
--- a/pkg/apis/networking/v1/utils.go
+++ b/pkg/apis/networking/v1/utils.go
@@ -19,6 +19,7 @@ package v1
 import (
 	"fmt"
 	"math"
+	"math/big"
 	"net"
 	"strconv"
 	"strings"
@@ -190,7 +191,7 @@ func IsSubnetAutoNatOutgoing(subnetSpec *SubnetSpec) bool {
 	return *subnetSpec.Config.AutoNatOutgoing
 }
 
-func CalculateCapacity(ar *AddressRange) int64 {
+func CalculateCapacity(ar *AddressRange) *big.Int {
 	var (
 		cidr       *net.IPNet
 		start, end net.IP
@@ -198,7 +199,7 @@ func CalculateCapacity(ar *AddressRange) int64 {
 	)
 
 	if _, cidr, err = net.ParseCIDR(ar.CIDR); err != nil {
-		return math.MaxInt64
+		return big.NewInt(math.MaxInt64)
 	}
 
 	if len(ar.Start) > 0 {
@@ -215,7 +216,7 @@ func CalculateCapacity(ar *AddressRange) int64 {
 		end = utils.LastIP(cidr)
 	}
 
-	return utils.Capacity(start, end) - int64(len(ar.ExcludeIPs))
+	return big.NewInt(0).Sub(utils.Capacity(start, end), big.NewInt(int64(len(ar.ExcludeIPs))))
 }
 
 func IsAvailable(statistics *Count) bool {

--- a/pkg/apis/networking/v1/utils_test.go
+++ b/pkg/apis/networking/v1/utils_test.go
@@ -19,6 +19,7 @@ package v1
 import (
 	"fmt"
 	"math"
+	"math/big"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -288,7 +289,7 @@ func TestCalculateCapacity(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			if calculated := CalculateCapacity(test.addressRange); calculated != test.expected {
+			if calculated := CalculateCapacity(test.addressRange); calculated.Cmp(big.NewInt(test.expected)) != 0 {
 				t.Fatalf("test %s fails, expected %d but calculated %d", test.name, test.expected, calculated)
 			}
 		})

--- a/pkg/utils/cidr.go
+++ b/pkg/utils/cidr.go
@@ -62,18 +62,22 @@ func Cmp(a, b net.IP) int {
 // Capacity returns the absolute number of IPs between a and b.
 // 0 is returned if a and b are of different IP families, or
 // any of those two IPs is invalid.
-func Capacity(a, b net.IP) int64 {
+func Capacity(a, b net.IP) *big.Int {
 	normalizedA := normalizeIP(a)
 	normalizedB := normalizeIP(b)
 
 	if normalizedA == nil || normalizedB == nil || len(normalizedA) != len(normalizedB) {
-		return 0
+		return big.NewInt(0)
 	}
 
 	ai := ipToInt(normalizedA)
 	bi := ipToInt(normalizedB)
 
-	return big.NewInt(0).Abs(big.NewInt(0).Sub(bi, ai)).Int64() + 1
+	return big.NewInt(0).Add(
+		big.NewInt(0).Abs(
+			big.NewInt(0).Sub(bi, ai),
+		), big.NewInt(1),
+	)
 }
 
 func ipToInt(ip net.IP) *big.Int {

--- a/pkg/utils/cidr_test.go
+++ b/pkg/utils/cidr_test.go
@@ -17,6 +17,7 @@
 package utils
 
 import (
+	"math/big"
 	"net"
 	"reflect"
 	"testing"
@@ -183,47 +184,55 @@ func TestCapacity(t *testing.T) {
 	testCases := []struct {
 		a      net.IP
 		b      net.IP
-		result int64
+		result *big.Int
 	}{
 		{
 			net.ParseIP("192.168.0.1"),
 			net.ParseIP("192.168.0.2"),
-			2,
+			big.NewInt(2),
 		},
 		{
 			net.ParseIP("192.168.0.1"),
 			net.ParseIP("192.168.0.1"),
-			1,
+			big.NewInt(1),
 		},
 		{
 			net.ParseIP("192.168.0.1"),
 			net.ParseIP("AB12::210"),
-			0,
+			big.NewInt(0),
 		},
 		{
 			net.ParseIP("192.168.0.2"),
 			[]byte{192, 168, 5},
-			0,
+			big.NewInt(0),
 		},
 		{
 			net.ParseIP("AB12::123"),
 			net.ParseIP("AB12::210"),
-			238,
+			big.NewInt(238),
 		},
 		{
 			net.ParseIP("AB12::210"),
 			net.ParseIP("AB12::123"),
-			238,
+			big.NewInt(238),
 		},
 		{
 			net.ParseIP("AB12::123"),
 			net.ParseIP("AB12::123"),
-			1,
+			big.NewInt(1),
+		},
+		{
+			net.ParseIP("2001:db8:acad:3::ff"),
+			net.ParseIP("2001:db8:acad:3:ffff:ffff:ffff:fffe"),
+			big.NewInt(0).Sub(
+				big.NewInt(0).Lsh(big.NewInt(1), 64),
+				big.NewInt(0).Lsh(big.NewInt(1), 8),
+			),
 		},
 	}
 	for _, test := range testCases {
 		outcome := Capacity(test.a, test.b)
-		if outcome != test.result {
+		if outcome.Cmp(test.result) != 0 {
 			t.Errorf("expect result %d but got %d", test.result, outcome)
 		}
 	}

--- a/pkg/webhook/validating/subnet.go
+++ b/pkg/webhook/validating/subnet.go
@@ -19,6 +19,7 @@ package validating
 import (
 	"context"
 	"fmt"
+	"math/big"
 	"net/http"
 	"reflect"
 	"strings"
@@ -115,7 +116,7 @@ func SubnetCreateValidation(ctx context.Context, req *admission.Request, handler
 	}
 
 	// Capacity validation
-	if capacity := networkingv1.CalculateCapacity(&subnet.Spec.Range); capacity > MaxSubnetCapacity {
+	if capacity := networkingv1.CalculateCapacity(&subnet.Spec.Range); capacity.Cmp(big.NewInt(MaxSubnetCapacity)) == 1 {
 		return webhookutils.AdmissionDeniedWithLog(fmt.Sprintf("subnet contains more than %d IPs", MaxSubnetCapacity), logger)
 	}
 


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/hybridnet/blob/main/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

Pull Request Description
---

### Describe what this PR does / why we need it
To correct the calculation of ipv6 subnet capacity.

### Does this pull request fix one issue?
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
Fix #357 

### Describe how you did it

### Describe how to verify it

### Special notes for reviews