### PR TITLE
improve: skip local vtep when generate vxlan fdb entry

### DIFF
--- a/pkg/daemon/vxlan/vxlan.go
+++ b/pkg/daemon/vxlan/vxlan.go
@@ -113,7 +113,10 @@ func (dev *Device) Link() *netlink.Vxlan {
 }
 
 func (dev *Device) RecordVtepInfo(vtepMac net.HardwareAddr, vtepIP net.IP) {
-	dev.remoteIPToMacMap[vtepIP.String()] = vtepMac
+	// exclude local vtep when collect remote vtep information.
+	if dev.link.HardwareAddr.String() != vtepMac.String() {
+		dev.remoteIPToMacMap[vtepIP.String()] = vtepMac
+	}
 }
 
 func (dev *Device) SyncVtepInfo(execDel bool) error {


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/hybridnet/blob/main/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

Pull Request Description
---

### Describe what this PR does / why we need it

### Does this pull request fix one issue?
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it

### Describe how to verify it

### Special notes for reviews