### PR TITLE
only reserver ip instance after pod terminated

### DIFF
--- a/pkg/controllers/networking/pod_controller.go
+++ b/pkg/controllers/networking/pod_controller.go
@@ -144,6 +144,11 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result
 		}
 
 		if strategy.OwnByStatefulWorkload(ownedObj) {
+			// Before pod terminated, should not reserve ip instance because of pre-stop
+			if !utils.PodIsTerminated(pod) {
+				return ctrl.Result{}, nil
+			}
+
 			if err = r.reserve(ctx, pod); err != nil {
 				return ctrl.Result{}, wrapError("unable to reserve pod", err)
 			}
@@ -164,6 +169,11 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result
 				if apierrors.IsNotFound(err) || !vm.DeletionTimestamp.IsZero() {
 					// if vm is deleted, should not reserve pod ips any more
 					return ctrl.Result{}, wrapError("unable to remove finalizer", r.removeFinalizer(ctx, pod))
+				}
+
+				// Before pod terminated, should not reserve ip instance because of pre-stop
+				if !utils.PodIsTerminated(pod) {
+					return ctrl.Result{}, nil
 				}
 
 				log.V(1).Info("reserve ip for VM pod")

--- a/pkg/controllers/utils/pod.go
+++ b/pkg/controllers/utils/pod.go
@@ -51,4 +51,14 @@ func PodIsScheduled(pod *v1.Pod) bool {
 	return len(pod.Spec.NodeName) > 0
 }
 
+func PodIsTerminated(pod *v1.Pod) bool {
+	for i := range pod.Status.ContainerStatuses {
+		if pod.Status.ContainerStatuses[i].State.Terminated == nil {
+			return false
+		}
+	}
+
+	return true
+}
+
 var ParseNetworkConfigOfPodByPriority = utils.ParseNetworkConfigOfPodByPriority


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/hybridnet/blob/main/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

Pull Request Description
---

### Describe what this PR does / why we need it
IPInstance reservation happens immediately after pod terminating now, so `preStop` will lose network connectivity because of this.

### Does this pull request fix one issue?
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
NONE

### Describe how you did it
To avoid losing network connectivity when pre-stopping, we should reserve ip instance only after pod terminated, which means all containers of pod do not need network connectivity any more.

### Describe how to verify it
Integration test will do this.

### Special notes for reviews
NONE