### PR TITLE
bugfix: waiting containers block pod termination

### DIFF
--- a/pkg/controllers/networking/pod_controller.go
+++ b/pkg/controllers/networking/pod_controller.go
@@ -145,7 +145,7 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result
 
 		if strategy.OwnByStatefulWorkload(ownedObj) {
 			// Before pod terminated, should not reserve ip instance because of pre-stop
-			if !utils.PodIsTerminated(pod) {
+			if !utils.PodIsNotRunning(pod) {
 				return ctrl.Result{}, nil
 			}
 
@@ -167,12 +167,12 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result
 				}
 
 				if apierrors.IsNotFound(err) || !vm.DeletionTimestamp.IsZero() {
-					// if vm is deleted, should not reserve pod ips any more
+					// if vm is deleted, should not reserve pod ips anymore
 					return ctrl.Result{}, wrapError("unable to remove finalizer", r.removeFinalizer(ctx, pod))
 				}
 
-				// Before pod terminated, should not reserve ip instance because of pre-stop
-				if !utils.PodIsTerminated(pod) {
+				// Before pod is not running, should not reserve ip instance because of pre-stop
+				if !utils.PodIsNotRunning(pod) {
 					return ctrl.Result{}, nil
 				}
 

--- a/pkg/controllers/networking/pod_controller_test.go
+++ b/pkg/controllers/networking/pod_controller_test.go
@@ -701,7 +701,7 @@ var _ = Describe("Pod controller integration test suite", func() {
 			Expect(k8sClient.Delete(context.Background(), pod, client.GracePeriodSeconds(0))).NotTo(HaveOccurred())
 		})
 
-		It("Check ip reserved only after pod terminated", func() {
+		It("Check ip reserved only after pod is not running", func() {
 			By("create a stateful pod requiring IPv4 address")
 			var ipInstanceName string
 			pod := simplePodRender(podName, node1Name)
@@ -740,13 +740,15 @@ var _ = Describe("Pod controller integration test suite", func() {
 				WithPolling(time.Second).
 				Should(Succeed())
 
-			By("update to make sure pod not terminated")
+			By("update to make sure pod is running")
 			patch := client.MergeFrom(pod.DeepCopy())
 			pod.Status.ContainerStatuses = []corev1.ContainerStatus{
 				{
 					Name: "test",
 					State: corev1.ContainerState{
-						Terminated: nil,
+						Running: &corev1.ContainerStateRunning{
+							StartedAt: metav1.Time{Time: time.Now()},
+						},
 					},
 				},
 			}
@@ -770,13 +772,13 @@ var _ = Describe("Pod controller integration test suite", func() {
 				WithPolling(5 * time.Second).
 				Should(Succeed())
 
-			By("update to make sure pod terminated")
+			By("update to make sure pod is not running")
 			patch = client.MergeFrom(pod.DeepCopy())
 			pod.Status.ContainerStatuses = []corev1.ContainerStatus{
 				{
 					Name: "test",
 					State: corev1.ContainerState{
-						Terminated: &corev1.ContainerStateTerminated{},
+						Running: nil,
 					},
 				},
 			}

--- a/pkg/controllers/utils/pod.go
+++ b/pkg/controllers/utils/pod.go
@@ -51,9 +51,10 @@ func PodIsScheduled(pod *v1.Pod) bool {
 	return len(pod.Spec.NodeName) > 0
 }
 
-func PodIsTerminated(pod *v1.Pod) bool {
+func PodIsNotRunning(pod *v1.Pod) bool {
+	// check if all the pod containers are not running, if any container is running, pod is still running
 	for i := range pod.Status.ContainerStatuses {
-		if pod.Status.ContainerStatuses[i].State.Terminated == nil {
+		if pod.Status.ContainerStatuses[i].State.Running != nil {
 			return false
 		}
 	}


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/hybridnet/blob/main/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

Pull Request Description
---

### Describe what this PR does / why we need it
As mentioned in #406, now sts pods might get stuck in "Terminating" because of unknow _waiting_ container state. To check if pod is completely terminated, we should check if "all the containers' state are not _running_" rather than "all the containers‘ state are _terminated_".

### Does this pull request fix one issue?
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->
Fixes #406 

### Describe how you did it

### Describe how to verify it

### Special notes for reviews